### PR TITLE
Allow setting primary read action as default page for resource

### DIFF
--- a/lib/ash_admin/api.ex
+++ b/lib/ash_admin/api.ex
@@ -12,6 +12,12 @@ defmodule AshAdmin.Api do
         default: false,
         doc: "Wether or not this api and its resources should be included in the admin dashboard"
       ],
+      primary_read_default?: [
+        type: :boolean,
+        default: false,
+        doc:
+          "Should the default page for the resource be the primary read action or the schema view?"
+      ],
       resource_group_labels: [
         type: :keyword_list,
         default: [],
@@ -40,6 +46,10 @@ defmodule AshAdmin.Api do
 
   def show?(api) do
     Ash.Dsl.Extension.get_opt(api, [:admin], :show?, false, true)
+  end
+
+  def primary_read_default?(api) do
+    Ash.Dsl.Extension.get_opt(api, [:admin], :primary_read_default?, false, true)
   end
 
   def resource_group_labels(api) do

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -144,7 +144,7 @@ defmodule AshAdmin.PageLive do
         "update" -> :update
         "create" -> :create
         "destroy" -> :destroy
-        nil -> nil
+        nil -> if AshAdmin.Api.primary_read_default?(socket.assigns.api), do: :read, else: nil
       end
 
     if action_type do
@@ -156,10 +156,10 @@ defmodule AshAdmin.PageLive do
       if action do
         assign(socket, action_type: action_type, action: action)
       else
-        assign(socket, action: nil, action_type: nil)
+        assign(socket, action_type: nil, action: nil)
       end
     else
-      assign(socket, action: nil, action_type: nil)
+      assign(socket, action_type: nil, action: nil)
     end
   end
 


### PR DESCRIPTION
First pass at adding ability to set primary read action as default page for resource.

This seemed a like a simpler approach:
- boolean value means you can't mess it up (didn't see a way to validate the atom value)
- where there no primary action or it's set to the default we just fallback to showing the schema as before