### PR TITLE
feature: add default page override option for resource 

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,6 +3,7 @@
 locals_without_parens = [
   actor?: 1,
   create_actions: 1,
+  default_page: 1,
   default_resource_page: 1,
   destroy_actions: 1,
   field: 1,

--- a/lib/ash_admin/api.ex
+++ b/lib/ash_admin/api.ex
@@ -14,7 +14,7 @@ defmodule AshAdmin.Api do
           "Whether or not this API and its resources should be included in the admin dashboard."
       ],
       default_resource_page: [
-        type: {:in, [:schema, :primary_read]},
+        type: {:in, [:schema, :read]},
         default: :schema,
         doc:
           "Set the default page for the resource to be the primary read action or the resource schema. Schema is the default for backwards compatibility, if a resource doesn't have a primary read action it will fallback to the schema view."

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -138,11 +138,20 @@ defmodule AshAdmin.PageLive do
   end
 
   defp assign_action(socket, action, action_type) do
+    resource = socket.assigns.resource
+
     action_type = get_action_type(socket.assigns.api, action_type)
+    case action_type do
+      nil ->
+            if result = AshAdmin.Resource.default_page(resource) do
+      {:action, action} = result |> IO.inspect()
+      assign(socket, action_type: action_type, action: Ash.Resource.Info.action(resource, action))
+      _ ->
+    end
 
     action =
-      find_action(socket.assigns.resource, action, action_type) ||
-        AshAdmin.Helpers.primary_action(socket.assigns.resource, action_type)
+      find_action(resource, action, action_type) ||
+        AshAdmin.Helpers.primary_action(resource, action_type)
 
     if action && action_type do
       assign(socket, action_type: action_type, action: action)

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -138,27 +138,7 @@ defmodule AshAdmin.PageLive do
   end
 
   defp assign_action(socket, action, action_type) do
-    action_type =
-      case action_type do
-        "read" ->
-          :read
-
-        "update" ->
-          :update
-
-        "create" ->
-          :create
-
-        "destroy" ->
-          :destroy
-
-        nil ->
-          if AshAdmin.Api.default_resource_page(socket.assigns.api) == :primary_read,
-            do: :read,
-            else: nil
-      end
-
-    if action_type do
+    if action_type = get_action_type(socket.assigns.api, action_type) do
       action =
         Enum.find(Ash.Resource.Info.actions(socket.assigns.resource), fn resource_action ->
           to_string(resource_action.name) == action && resource_action.type == action_type
@@ -171,6 +151,19 @@ defmodule AshAdmin.PageLive do
       end
     else
       assign(socket, action_type: nil, action: nil)
+    end
+  end
+
+  defp get_action_type(_, "read"), do: :read
+  defp get_action_type(_, "update"), do: :update
+  defp get_action_type(_, "create"), do: :create
+  defp get_action_type(_, "destroy"), do: :destroy
+
+  defp get_action_type(api, _) do
+    if AshAdmin.Api.default_resource_page(api) == :primary_read do
+      :read
+    else
+      nil
     end
   end
 

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -157,7 +157,7 @@ defmodule AshAdmin.PageLive do
   defp get_action_type(_, "destroy"), do: :destroy
 
   defp get_action_type(api, _) do
-    if AshAdmin.Api.default_resource_page(api) == :primary_read do
+    if AshAdmin.Api.default_resource_page(api) == :read do
       :read
     else
       nil

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -138,17 +138,14 @@ defmodule AshAdmin.PageLive do
   end
 
   defp assign_action(socket, action, action_type) do
-    if action_type = get_action_type(socket.assigns.api, action_type) do
-      action =
-        Enum.find(Ash.Resource.Info.actions(socket.assigns.resource), fn resource_action ->
-          to_string(resource_action.name) == action && resource_action.type == action_type
-        end) || AshAdmin.Helpers.primary_action(socket.assigns.resource, action_type)
+    action_type = get_action_type(socket.assigns.api, action_type)
 
-      if action do
-        assign(socket, action_type: action_type, action: action)
-      else
-        assign(socket, action_type: nil, action: nil)
-      end
+    action =
+      find_action(socket.assigns.resource, action, action_type) ||
+        AshAdmin.Helpers.primary_action(socket.assigns.resource, action_type)
+
+    if action && action_type do
+      assign(socket, action_type: action_type, action: action)
     else
       assign(socket, action_type: nil, action: nil)
     end
@@ -165,6 +162,12 @@ defmodule AshAdmin.PageLive do
     else
       nil
     end
+  end
+
+  defp find_action(resource, action, action_type) do
+    Enum.find(Ash.Resource.Info.actions(resource), fn resource_action ->
+      to_string(resource_action.name) == action && resource_action.type == action_type
+    end)
   end
 
   defp assign_tables(socket, table) do

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -146,8 +146,6 @@ defmodule AshAdmin.PageLive do
 
     action_type = get_action_type(resource_default_action, api_default_action_type, action_type)
 
-    IO.inspect({api_default_action_type, resource_default_action, action_type})
-
     {action_type, action} =
       set_action(resource, action_type, action, resource_default_action, api_default_action_type)
 
@@ -155,20 +153,26 @@ defmodule AshAdmin.PageLive do
   end
 
   defp set_action(resource, action_type, action, resource_default_action, api_default_action_type) do
-    case {action_type, resource_default_action, api_default_action_type} do
-      {nil, {:action, action}, _} ->
-        action_struct = Ash.Resource.Info.action(resource, action)
-        {action_struct.type, action_struct}
+    IO.inspect({action_type, resource_default_action, api_default_action_type}, label: "!!!")
 
+    case {action_type, resource_default_action, api_default_action_type} do
       {nil, :schema, _} ->
         {nil, nil}
 
       {nil, _, :schema} ->
         {nil, nil}
 
-      {nil, _, api_default_action_type} ->
+      {nil, {:action, action}, _} ->
+        action_struct = Ash.Resource.Info.action(resource, action)
+        {action_struct.type, action_struct}
+
+      {nil, nil, api_default_action_type} ->
         {api_default_action_type,
          AshAdmin.Helpers.primary_action(resource, api_default_action_type)}
+
+      {nil, resource_default_action_type, _} when not is_nil(resource_default_action_type) ->
+        {resource_default_action_type,
+         AshAdmin.Helpers.primary_action(resource, resource_default_action_type)}
 
       {action_type, _, _} ->
         if action_struct =

--- a/lib/ash_admin/resource/resource.ex
+++ b/lib/ash_admin/resource/resource.ex
@@ -86,7 +86,7 @@ defmodule AshAdmin.Resource do
              {:custom, __MODULE__, :action_tuple, []}
            ]},
         doc:
-          "The default landing page for the resource. Can be `:schema | action_type | {:action, action_name} | {:custom, custom_page_name}`"
+          "The default landing page for the resource. Can be `:schema | action_type | {:action, action_name}`"
       ]
     ]
   }

--- a/lib/ash_admin/resource/resource.ex
+++ b/lib/ash_admin/resource/resource.ex
@@ -191,11 +191,11 @@ defmodule AshAdmin.Resource do
     end)
   end
 
-  def action_tuple({:action, action_name}, _) when is_atom(action_name) do
+  def action_tuple({:action, action_name}) when is_atom(action_name) do
     {:ok, {:action, action_name}}
   end
 
-  def action_tuple(invalid, _) do
+  def action_tuple(invalid) do
     {:error, "Expected `{:action, action_name}`, got: #{inspect(invalid)}"}
   end
 


### PR DESCRIPTION
Currently this option can be set to one of the following:

- `:schema`
- `:read`
- `:create`
- `:update`
- `:destroy`
- `{:action, action_name}`

Will implement the ability to specify a custom page later with:

- `{:custom, custom_page_name}`