### PR TITLE
Skip check for embedded types when rendering attributes

### DIFF
--- a/lib/ash_admin/components/resource/table.ex
+++ b/lib/ash_admin/components/resource/table.ex
@@ -91,11 +91,7 @@ defmodule AshAdmin.Components.Resource.Table do
   end
 
   defp render_attribute(api, record, attribute, formats) do
-    if Ash.Type.embedded_type?(attribute.type) do
-      "..."
-    else
-      process_attribute(api, record, attribute, formats)
-    end
+    process_attribute(api, record, attribute, formats)
   rescue
     _ ->
       "..."


### PR DESCRIPTION
This blows up for relationships, where the `attribute.type` is something like `:belongs_to` (instead of a module name like `Ash.Type.String`), meaning that relationships are always rendered as `...`.

Fixes issue caused by
https://github.com/ash-project/ash/commit/6aa0c0b591576c26327149e95cbbcc42611cff6d#diff-dd4491b1dc2629842f30d2edee72161d609bc73dff8e10a3b3e61f60b4ffc756L176-R177

I'm not sure if this is the best place to fix it (or if the issue may affect other things within Ash), but I noticed it while using ash_admin so thought I'd fix it here!