### PR TITLE
fix: changelog URL in release tweet

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -112,7 +112,7 @@ jobs:
             #myelixirstatus
 
             See the changelog for more info:
-            https://github.com/ash-project/ash_phoenix/blob/main/CHANGELOG.md
+            https://github.com/ash-project/ash_admin/blob/main/CHANGELOG.md
           consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
           consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
           access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
The changelog URL in the auto release tweet was pointing at ash_phoenix, now correctly points at ash_admin