### PR TITLE
fix: Binary data display

### DIFF
--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -553,6 +553,12 @@ defmodule AshAdmin.Components.Resource.Form do
     """
   end
 
+  def render_attribute_input(assigns, %{type: Ash.Type.Binary}, _form, _value, _name) do
+    ~F"""
+    <span class="italic">(binary fields cannot be edited)</span>
+    """
+  end
+
   def render_attribute_input(
         assigns,
         %{

--- a/lib/ash_admin/components/resource/show.ex
+++ b/lib/ash_admin/components/resource/show.ex
@@ -315,6 +315,18 @@ defmodule AshAdmin.Components.Resource.Show do
     end
   end
 
+  defp render_attribute(assigns, _resource, record, %{name: name, type: Ash.Type.Binary}, _) do
+    if Map.get(record, name) do
+      ~F"""
+      <span class="italic">(binary data)</span>
+      """
+    else
+      ~F"""
+      (empty)
+      """
+    end
+  end
+
   defp render_attribute(assigns, resource, record, attribute, nested?) do
     if Ash.Type.embedded_type?(attribute.type) do
       both_classes = "ml-1 pl-2 pr-2"

--- a/lib/ash_admin/components/resource/table.ex
+++ b/lib/ash_admin/components/resource/table.ex
@@ -134,14 +134,22 @@ defmodule AshAdmin.Components.Resource.Table do
       |> Map.get(attribute.name)
       |> (&apply(mod, func, [&1] ++ args)).()
 
-    format_attribute_value(data)
+    format_attribute_value(data, attribute)
   end
 
   defp process_attribute(_api, _record, _attr, _formats) do
     "..."
   end
 
-  defp format_attribute_value(data) do
+  defp format_attribute_value(data, %{type: Ash.Type.Binary}) when data not in [[], nil, ""] do
+    assigns = %{}
+
+    ~F"""
+    <span class='italic'>(binary)</span>
+    """
+  end
+
+  defp format_attribute_value(data, _attribute) do
     if is_binary(data) and !String.valid?(data) do
       "..."
     else


### PR DESCRIPTION
I noticed while starting to work with binary blobs of data, that admin would happily try to render them - 

<img width="945" alt="Screen Shot 2022-08-25 at 4 01 45 pm" src="https://user-images.githubusercontent.com/543859/186609645-8fb41cc7-c314-41f2-9933-1da0db1d83a5.png">

And then cowboy would crash in a loop - 

```
[error] Ranch listener AppName.Endpoint.HTTP had connection process started with 
:cowboy_clear:start_link/4 at #PID<0.1167.0> exit with reason: {%Jason.EncodeError{message: 
"invalid byte 0xFF in <<255, 216, 255, 224, ...
```

Same when editing the records 😭 

This is some super-quick fixes to stop that from happening - italic text is used to represent the attribute contents that shouldn't be displayed or edited as-is.

<img width="873" alt="Screen Shot 2022-08-25 at 4 05 04 pm" src="https://user-images.githubusercontent.com/543859/186610320-18783582-f9b8-48ff-aaa2-6a465c0042b3.png">

<img width="446" alt="Screen Shot 2022-08-25 at 4 06 17 pm" src="https://user-images.githubusercontent.com/543859/186610602-5df1293a-5b37-400f-9d06-92a8cb60d02a.png">

