### PR TITLE
fix: Fix `undefined function locals_without_parens/0` error

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -22,8 +22,8 @@ spark_locals_without_parens = [
 
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  locals_without_parens: locals_without_parens,
+  locals_without_parens: spark_locals_without_parens,
   export: [
-    locals_without_parens: locals_without_parens
+    locals_without_parens: spark_locals_without_parens
   ]
 ]


### PR DESCRIPTION
This variable was renamed, but references to it were not.

The previous version gave the error:

```
$ mix format --check-formatted
warning: variable "locals_without_parens" does not exist and is being expanded to "locals_without_parens()", please use parentheses to remove the ambiguity or change the variable name
  deps/ash_admin/.formatter.exs:25

** (CompileError) deps/ash_admin/.formatter.exs:25: undefined function locals_without_parens/0 (there is no such import)
```

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
