### PR TITLE
chore: fix markdown in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,15 +8,18 @@ assignees: ''
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is. If you are not sure if the bug is related to `ash` or an extension, log it with [ash](https://github.com/ash-project/ash/issues/new) and we will move it.
 
 **To Reproduce**
+
 A minimal set of resource definitions and calls that can reproduce the bug.
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
-** Runtime
+**Runtime**
  - Elixir version
  - Erlang version
  - OS
@@ -24,4 +27,5 @@ A clear and concise description of what you expected to happen.
  - any related extension versions
 
 **Additional context**
+
 Add any other context about the problem here.


### PR DESCRIPTION
**Before**

<img width="1079" alt="Screen Shot 2022-12-12 at 6 02 38 PM" src="https://user-images.githubusercontent.com/439309/207065318-550af108-a673-49ab-9ab2-69263e3a6277.png">

**After**

<img width="1040" alt="Screen Shot 2022-12-12 at 6 03 14 PM" src="https://user-images.githubusercontent.com/439309/207065436-b11a299a-f48d-4796-9f2a-1d46800a41a7.png">
