### PR TITLE
feat: Inline style nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ end
 
 Now start your project (usually by running `mix phx.server` in a terminal) and visit `/admin` in your browser (or whatever path you gave to `ash_admin` in your router).
 
+### Content Security Policy
+
+If your app specifies a content security policy header, eg. via
+
+```elixir
+plug :put_secure_browser_headers, %{"content-security-policy" => "default-src 'self'"}
+```
+
+in your router, then all of the styles and JavaScript used to power AshAdmin will be blocked by your browser.
+
+To avoid this, you can add the specific AshAdmin nonces to the `default-src` allowlist, ie.
+
+```elixir
+plug :put_secure_browser_headers, %{"content-security-policy" => "default-src 'nonce-ash_admin-Ed55GFnX' 'self'"}
+```
+
+This will allow AshAdmin-generated inline CSS and JS blocks to execute normally.
+
 ## Configuration
 
 See the documentation in [`AshAdmin.Resource`](https://hexdocs.pm/ash_admin/AshAdmin.Resource.html) and [`AshAdmin.Api`](https://hexdocs.pm/ash_admin/AshAdmin.Api.html) for information on the available configuration.
@@ -85,7 +103,6 @@ To work on ash_admin, you'll want to be able to run the dev app. You'll need to 
 Then, you can start the app with: `mix dev`
 
 If you make changes to the resources, you can generate migrations with `mix generate_migrations`
-
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,6 @@ First, ensure you've added ash_admin to your `mix.exs` file.
 {:ash_admin, "~> 0.7.1"}
 ```
 
-## Phoenix 1.7
-
-If you want to use Phoenix 1.7 which has not yet been released, you'll need to use the git branch `phoenix-1.7`, i.e
-
-```elixir
-{:ash_admin, github: "ash-project/ash_admin", branch: "phoenix-1.7"}
-```
-
 ## Setup
 
 Ensure your apis are configured in `config.exs`

--- a/lib/ash_admin/templates/admin.html.eex
+++ b/lib/ash_admin/templates/admin.html.eex
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>
     <%= csrf_meta_tag() %>
     <title><%= assigns[:page_title] || "Ash Admin" %></title>
-    <style><%= raw(render("app.css")) %></style>
+    <style nonce="ash_admin-Ed55GFnX"><%= raw(render("app.css")) %></style>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.5.1/jsoneditor.min.css" rel="stylesheet" type="text/css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.5.1/jsoneditor.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
@@ -16,5 +16,5 @@
     <%= @inner_content %>
   </body>
 </body>
-<script><%= raw(render("app.js")) %></script>
+<script nonce="ash_admin-Ed55GFnX"><%= raw(render("app.js")) %></script>
 </html>

--- a/mix.exs
+++ b/mix.exs
@@ -94,7 +94,7 @@ defmodule AshAdmin.MixProject do
       {:ash, "~> 2.0"},
       {:ash_phoenix, "~> 1.1"},
       {:phoenix_view, "~> 2.0"},
-      {:phoenix, "1.7.0-rc.0", override: true},
+      {:phoenix, "~> 1.7"},
       {:surface, "~> 0.9.1"},
       {:phoenix_live_view, "~> 0.18.3"},
       {:phoenix_html, "~> 3.2"},


### PR DESCRIPTION
I ran into an issue where inline styles provided by AshAdmin were being blocked by the CSP set for our app, and after a bit of research I found that you can specify nonces on specific inline CSS/JS blocks to allow them to be executed. 

Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles

So I've added nonces to the blocks for the main CSS/JS content, updated the CSP in my app that uses AshAdmin, and presto, it works again!

(Note: There are still some CSP violations, for the markdown editor/JSON editor also loaded in the admin layout - as they are truly external files I didn't want to touch them here.)