### PR TITLE
fix: Admin links are not aware of the scope where ash_admin is called

### DIFF
--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -21,11 +21,12 @@ defmodule AshAdmin.PageLive do
   def mount(
         _params,
         %{
-          "prefix" => prefix
+          "prefix" => _prefix
         } = session,
         socket
       ) do
     otp_app = socket.endpoint.config(:otp_app)
+    prefix = session["prefix"]
     socket = assign(socket, :prefix, prefix)
 
     actor_paused =

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -21,12 +21,23 @@ defmodule AshAdmin.PageLive do
   def mount(
         _params,
         %{
-          "prefix" => _prefix
+          "prefix" => prefix
         } = session,
         socket
       ) do
     otp_app = socket.endpoint.config(:otp_app)
-    prefix = session["prefix"]
+
+    prefix =
+      case prefix do
+        "/" ->
+          session["request_path"]
+
+        _ ->
+          request_path = session["request_path"]
+          [scope, _] = String.split(request_path, prefix)
+          scope <> prefix
+      end
+
     socket = assign(socket, :prefix, prefix)
 
     actor_paused =

--- a/lib/ash_admin/router.ex
+++ b/lib/ash_admin/router.ex
@@ -1,12 +1,4 @@
 defmodule AshAdmin.Router do
-  def init(_), do: []
-
-  def call(conn, opts) do
-    # @path conn.request_path
-    # ash_admin(conn.request_path, opts)
-    conn
-  end
-
   @moduledoc """
   Provides LiveView routing for AshAdmin.
   """
@@ -98,6 +90,8 @@ defmodule AshAdmin.Router do
   def __session__(conn, [session]), do: __session__(conn, session)
 
   def __session__(conn, session) do
+    session = Map.put(session, "prefix", conn.request_path)
+
     Enum.reduce(@cookies_to_replicate, session, fn cookie, session ->
       case conn.req_cookies[cookie] do
         value when value in [nil, "", "null"] ->

--- a/lib/ash_admin/router.ex
+++ b/lib/ash_admin/router.ex
@@ -90,7 +90,7 @@ defmodule AshAdmin.Router do
   def __session__(conn, [session]), do: __session__(conn, session)
 
   def __session__(conn, session) do
-    session = Map.put(session, "prefix", conn.request_path)
+    session = Map.put(session, "request_path", conn.request_path)
 
     Enum.reduce(@cookies_to_replicate, session, fn cookie, session ->
       case conn.req_cookies[cookie] do

--- a/lib/ash_admin/router.ex
+++ b/lib/ash_admin/router.ex
@@ -1,4 +1,12 @@
 defmodule AshAdmin.Router do
+  def init(_), do: []
+
+  def call(conn, opts) do
+    # @path conn.request_path
+    # ash_admin(conn.request_path, opts)
+    conn
+  end
+
   @moduledoc """
   Provides LiveView routing for AshAdmin.
   """

--- a/test/page_live_test.exs
+++ b/test/page_live_test.exs
@@ -10,10 +10,21 @@ defmodule AshAdmin.Test.PageLiveTest do
   end
 
   test "it renders the schema by default", %{conn: conn} do
-    {:ok, _view, html} = live(conn, "/Api/Post")
+    {:ok, _view, html} = live(conn, "/api/admin")
 
     assert html =~ "Attributes"
     assert html =~ "body"
     assert html =~ "String"
+
+    {:ok, _view, html} = live(conn, "/api/admin/test")
+
+    assert html =~ "Attributes"
+    assert html =~ "body"
+    assert html =~ "String"
+  end
+
+  test "it raises error when no route is found", %{conn: conn} do
+    assert_raise(Phoenix.Router.NoRouteError, fn -> live(conn, "/") end)
+    assert_raise(Phoenix.Router.NoRouteError, fn -> live(conn, "/Api/Post") end)
   end
 end

--- a/test/page_live_test.exs
+++ b/test/page_live_test.exs
@@ -1,7 +1,6 @@
 defmodule AshAdmin.Test.PageLiveTest do
   use ExUnit.Case, async: false
 
-  import Plug.Conn
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
   @endpoint AshAdmin.Test.Endpoint

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -6,8 +6,10 @@ defmodule AshAdmin.Test.Router do
     plug(:fetch_query_params)
   end
 
+  pipeline(:ash_admin, do: plug(AshAdmin.Router))
+
   scope "/" do
-    pipe_through(:browser)
+    pipe_through([:browser, :ash_admin])
     import AshAdmin.Router
 
     ash_admin("/")

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -6,10 +6,8 @@ defmodule AshAdmin.Test.Router do
     plug(:fetch_query_params)
   end
 
-  pipeline(:ash_admin, do: plug(AshAdmin.Router))
-
   scope "/" do
-    pipe_through([:browser, :ash_admin])
+    pipe_through(:browser)
     import AshAdmin.Router
 
     ash_admin("/")

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -6,10 +6,10 @@ defmodule AshAdmin.Test.Router do
     plug(:fetch_query_params)
   end
 
-  scope "/" do
+  scope "/api" do
     pipe_through(:browser)
     import AshAdmin.Router
 
-    ash_admin("/")
+    ash_admin("/admin")
   end
 end


### PR DESCRIPTION
Fixing issue https://github.com/ash-project/ash_admin/issues/45

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests


Came up with an initial idea for now how we can do it but `ash_admin/2` can't be called from within the `call/2`