### PR TITLE
Remove config :tails

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -59,8 +59,3 @@ if config_env() == :test do
       AshAdmin.Test.Api
     ]
 end
-
-config :tails,
-  themes: %{
-    default: %{}
-  }


### PR DESCRIPTION
This doesn't seem needed anymore, when running the project, it says it's the following:

     You have configured application :tails in your configuration file,
     but the application is not available.

     This usually means one of:

       1. You have not added the application as a dependency in a mix.exs file.

       2. You are configuring an application that does not really exist.

     Please ensure :tails exists or remove the configuration.

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
