### PR TITLE
fix(create-form): errors from removal of surface

### DIFF
--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -263,18 +263,18 @@ defmodule AshAdmin.Components.Resource.Form do
       </div>
     </div>
     <div :for={{relationship, argument, opts} <- relationship_args}>
-      <%= if relationship not in @skip and @argument.name not in @skip do %>
+      <%= if relationship not in @skip and argument.name not in @skip do %>
         <label
           class="block text-sm font-medium text-gray-700"
-          for={@form.name <> "[#{@argument.name}]"}
+          for={@form.name <> "[#{argument.name}]"}
         >
           <%= to_name(argument.name) %>
         </label>
         <%= render_relationship_input(
           assigns,
-          Ash.Resource.Info.relationship(@form.source.resource, @relationship),
+          Ash.Resource.Info.relationship(@form.source.resource, relationship),
           @form,
-          @argument,
+          argument,
           opts
         ) %>
       <% end %>


### PR DESCRIPTION
Seems like there has been a regression when removing surface.

Without these fixes I can't successfully load a create form when the form has a relationship

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
