### PR TITLE
UI consistency in top nav

### DIFF
--- a/lib/ash_admin/components/top_nav/tenant_form.ex
+++ b/lib/ash_admin/components/top_nav/tenant_form.ex
@@ -36,23 +36,27 @@ defmodule AshAdmin.Components.TopNav.TenantForm do
           </svg>
         </button>
       </.form>
-      <button :if={@tenant} phx-click={@clear_tenant}>
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 16 16"
-          fill="white"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
-          />
-        </svg>
-      </button>
       <a :if={!@editing_tenant} href="#" phx-click="start_editing_tenant" phx-target={@myself}>
-        <%= @tenant || "No tenant" %>
+        <%= "Tenant: #{@tenant}" || "No tenant" %>
       </a>
+            <button :if={@tenant} phx-click={@clear_tenant}>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 16 16"
+              fill="white"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"
+              />
+              <path
+                fill-rule="evenodd"
+                d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
+              />
+            </svg>
+      </button>
     </div>
     """
   end


### PR DESCRIPTION
Adds a label for the Tenant in the Top Nav, moves the X icon to the right and uses the same X icon as Actor.

Before:
<img width="829" alt="CleanShot 2023-08-02 at 16 04 59@2x" src="https://github.com/ash-project/ash_admin/assets/8323/055a7b83-4d5b-46f7-8219-ed34f9e4c316">


After:
<img width="845" alt="CleanShot 2023-08-02 at 16 01 28@2x" src="https://github.com/ash-project/ash_admin/assets/8323/7a7d9b1a-41fb-45f9-99f3-0bd70fbda86c">
