### PR TITLE
fix dialyzer warning in top nav tenant form

### DIFF
--- a/lib/ash_admin/components/top_nav/tenant_form.ex
+++ b/lib/ash_admin/components/top_nav/tenant_form.ex
@@ -37,7 +37,7 @@ defmodule AshAdmin.Components.TopNav.TenantForm do
         </button>
       </.form>
       <a :if={!@editing_tenant} href="#" phx-click="start_editing_tenant" phx-target={@myself}>
-        <%= "Tenant: #{@tenant}" || "No tenant" %>
+        <%= if @tenant, do: "Tenant: #{@tenant}", else: "No tenant" %>
       </a>
       <button :if={@tenant} phx-click={@clear_tenant}>
         <svg


### PR DESCRIPTION
```
lib/ash_admin/components/top_nav/tenant_form.ex:40:guard_fail
The guard clause:

when _ :: <<_::8, _::size(1)>> === nil

can never succeed.
```