### PR TITLE
Pass actor when fetching relationships attributes

### DIFF
--- a/lib/ash_admin/components/resource/data_table.ex
+++ b/lib/ash_admin/components/resource/data_table.ex
@@ -104,6 +104,7 @@ defmodule AshAdmin.Components.Resource.DataTable do
                 attributes={AshAdmin.Resource.table_columns(@resource)}
                 format_fields={AshAdmin.Resource.format_fields(@resource)}
                 prefix={@prefix}
+                actor={@actor}
               />
               <%= render_pagination_links(assigns, :bottom) %>
             </div>


### PR DESCRIPTION
I noticed that relationships were displayed in tables with None when policies were set for the foreign resource. It seems that the actor wasn't passed when loading the resource. This PR fixes just that.

### Contributor checklist

- [ ] Bug fixes include regression tests <-- no unit test currently exist.
- [ ] ~Features include unit/acceptance tests~
