### PR TITLE
fix: {:array, type} attributes return error `no nil values` and not

### DIFF
--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -1179,7 +1179,7 @@ defmodule AshAdmin.Components.Resource.Form do
             |> Phoenix.HTML.Form.input_value(String.to_existing_atom(field))
             |> Kernel.||([])
             |> indexed_list()
-            |> append_to_and_map(nil)
+            |> append_to_and_map("")
 
           new_params =
             Map.put(


### PR DESCRIPTION
input, this seems to fix it bypassing the rrror and successfully showing the input

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
