### PR TITLE
Adds show_sensitive_fields option to Resource to allow unredacting se…

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -15,6 +15,7 @@ spark_locals_without_parens = [
   resource_group_labels: 1,
   show?: 1,
   show_action: 1,
+  show_sensitive_fields: 1,
   table_columns: 1,
   type: 1,
   update_actions: 1

--- a/dev/repo/seeds.exs
+++ b/dev/repo/seeds.exs
@@ -13,8 +13,8 @@ defmodule Demo.Seeder do
     })
   end
 
-  @spec insert_user!(String.t(), String.t(), String.t(), String.t()) :: User.t()
-  def insert_user!(first_name, last_name, bio, history) do
+  @spec insert_user!(String.t(), String.t(), String.t(), String.t(), String.t()) :: User.t()
+  def insert_user!(first_name, last_name, bio, history, api_key) do
     Seed.seed!(User, %{
       first_name: first_name,
       last_name: last_name,
@@ -22,6 +22,7 @@ defmodule Demo.Seeder do
         bio: bio,
         history: history,
       },
+      api_key: api_key,
       alternate_profiles: []
     })
   end
@@ -84,7 +85,7 @@ System.argv()
 
 Demo.Seeder.insert_admin!("Super", "Admin");
 org = Demo.Seeder.insert_organization!("Ash Project");
-Demo.Seeder.insert_user!("Alice", "Courtney", "Lorem ipsum dolor sit amet", "Duis aute irure dolor in reprehenderit in voluptate velit esse");
+Demo.Seeder.insert_user!("Alice", "Courtney", "Lorem ipsum dolor sit amet", "Duis aute irure dolor in reprehenderit in voluptate velit esse", "123456");
 bob = Demo.Seeder.insert_customer!("Bob", "Maclean");
 carol = Demo.Seeder.insert_representative!("Carol", "White");
 

--- a/documentation/dsls/DSL:-AshAdmin.Resource.cheatmd
+++ b/documentation/dsls/DSL:-AshAdmin.Resource.cheatmd
@@ -293,6 +293,26 @@ If this is not set, then *all* actions will require tables.
   </td>
 </tr>
 
+<tr>
+  <td style="text-align: left">
+    <a id="admin-show_sensitive_fields" href="#admin-show_sensitive_fields">
+      <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
+        show_sensitive_fields
+      </span>
+    </a>
+      
+  </td>
+  <td style="text-align: left">
+    <code class="inline">list(atom)</code>
+  </td>
+  <td style="text-align: left">
+    
+  </td>
+  <td style="text-align: left" colspan=2>
+    The list of fields that should not be redacted in the admin UI even if they are marked as sensitive.
+  </td>
+</tr>
+
   </tbody>
 </table>
 

--- a/lib/ash_admin/components/resource/data_table.ex
+++ b/lib/ash_admin/components/resource/data_table.ex
@@ -103,6 +103,7 @@ defmodule AshAdmin.Components.Resource.DataTable do
                 api={@api}
                 attributes={AshAdmin.Resource.table_columns(@resource)}
                 format_fields={AshAdmin.Resource.format_fields(@resource)}
+                show_sensitive_fields={AshAdmin.Resource.show_sensitive_fields(@resource)}
                 prefix={@prefix}
                 actor={@actor}
               />

--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -751,7 +751,7 @@ defmodule AshAdmin.Components.Resource.Form do
         ><%= value(@value, @form, @attribute) %></textarea>
       <% short_text?(@form.source.resource, @attribute) -> %>
         <.input
-          type={text_input_type(@attribute)}
+          type={text_input_type(@form.source.resource, @attribute)}
           id={@form.id <> "_#{@attribute.name}"}
           value={value(@value, @form, @attribute)}
           class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
@@ -760,7 +760,7 @@ defmodule AshAdmin.Components.Resource.Form do
         />
       <% true -> %>
         <.input
-          type={text_input_type(@attribute)}
+          type={text_input_type(@form.source.resource, @attribute)}
           placeholder={placeholder(@default)}
           id={@form.id <> "_#{@attribute.name}"}
           value={value(@value, @form, @attribute)}
@@ -954,7 +954,7 @@ defmodule AshAdmin.Components.Resource.Form do
 
     ~H"""
     <.input
-      type={text_input_type(@attribute)}
+      type={text_input_type(@form.source.resource, @attribute)}
       placeholder={placeholder(@attribute.default)}
       value={@casted_value}
       name={@name || @form.name <> "[#{@attribute.name}]"}
@@ -970,7 +970,7 @@ defmodule AshAdmin.Components.Resource.Form do
 
           ~H"""
           <.input
-            type={text_input_type(@attribute)}
+            type={text_input_type(@form.source.resource, @attribute)}
             placeholder={placeholder(@attribute.default)}
             value={@value}
             name={@name || @form.name <> "[#{@attribute.name}]"}
@@ -1076,8 +1076,17 @@ defmodule AshAdmin.Components.Resource.Form do
 
   defp placeholder(_), do: nil
 
-  defp text_input_type(%{sensitive?: true}), do: "password"
-  defp text_input_type(_), do: "text"
+  defp text_input_type(resource, %{name: name, sensitive?: true}) do
+    show_sensitive_fields = AshAdmin.Resource.show_sensitive_fields(resource)
+
+    if Enum.member?(show_sensitive_fields, name) do
+      "text"
+    else
+      "password"
+    end
+  end
+
+  defp text_input_type(_, _), do: "text"
 
   defp redirect_to(socket, record) do
     if AshAdmin.Resource.show_action(socket.assigns.resource) do

--- a/lib/ash_admin/components/resource/show.ex
+++ b/lib/ash_admin/components/resource/show.ex
@@ -276,8 +276,9 @@ defmodule AshAdmin.Components.Resource.Show do
 
   defp render_maybe_sensitive_attribute(assigns, resource, record, attribute) do
     assigns = assign(assigns, attribute: attribute)
+    show_sensitive_fields = AshAdmin.Resource.show_sensitive_fields(resource)
 
-    if attribute.sensitive? do
+    if attribute.sensitive? && not Enum.member?(show_sensitive_fields, attribute.name) do
       ~H"""
       <.live_component
         id={"#{@record.id}-#{@attribute.name}"}

--- a/lib/ash_admin/helpers.ex
+++ b/lib/ash_admin/helpers.ex
@@ -26,6 +26,14 @@ defmodule AshAdmin.Helpers do
     |> Enum.map_join(" ", &String.capitalize/1)
   end
 
+  def sensitive?(%Ash.Resource.Attribute{sensitive?: true}) do
+    true
+  end
+
+  def sensitive?(_) do
+    false
+  end
+
   def short_description(nil), do: {:not_split, nil}
 
   def short_description(description) do

--- a/lib/ash_admin/resource/resource.ex
+++ b/lib/ash_admin/resource/resource.ex
@@ -84,6 +84,11 @@ defmodule AshAdmin.Resource do
       resource_group: [
         type: :atom,
         doc: "The group in the top resource dropdown that the resource appears in."
+      ],
+      show_sensitive_fields: [
+        type: {:list, :atom},
+        doc:
+          "The list of fields that should not be redacted in the admin UI even if they are marked as sensitive."
       ]
     ]
   }
@@ -133,6 +138,10 @@ defmodule AshAdmin.Resource do
 
   def resource_group(resource) do
     Spark.Dsl.Extension.get_opt(resource, [:admin], :resource_group, nil, true)
+  end
+
+  def show_sensitive_fields(resource) do
+    Spark.Dsl.Extension.get_opt(resource, [:admin], :show_sensitive_fields, [], true)
   end
 
   def actor?(resource) do


### PR DESCRIPTION
This adds an option called `show_sensitive_fields` (accepts a list of atoms) to Resource that allows you to unredact sensitive fields from the admin panel.

Unredacted fields are treated the same as fields that aren't marked sensitive.

The main reason for this change is for people using the admin panel, it can be difficult to search for an item (eg. an email address) in a large table if it's hidden by default. This provides an escape hatch.