### PR TITLE
fix: loading multiple relationships with the same destination resourc…

### DIFF
--- a/lib/ash_admin/components/resource/show.ex
+++ b/lib/ash_admin/components/resource/show.ex
@@ -178,7 +178,8 @@ defmodule AshAdmin.Components.Resource.Show do
         data: data,
         destination: destination,
         context: context,
-        destination_attribute: destination_attribute
+        destination_attribute: destination_attribute,
+        relationship_name: name
       )
 
     ~H"""
@@ -190,6 +191,7 @@ defmodule AshAdmin.Components.Resource.Show do
         table={@context[:data_layer][:table]}
         prefix={@prefix}
         skip={[@destination_attribute]}
+        relationship_name={@relationship_name}
       />
     </div>
     """


### PR DESCRIPTION
…e that has sensitive fields

Duplicate ID error is raised when a resource with sensitive attributes is present more than once on admin pages.

** (RuntimeError) found duplicate ID "a9f8b9fe-c1be-471e-b7c6-973cc1152e15-history" for component AshAdmin.Components.Resource.SensitiveAttribute when rendering template

please let me know if there's better way of doing this.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
