### PR TITLE
fix: small refactor in actor plug

### DIFF
--- a/lib/ash_admin/actor_plug/plug.ex
+++ b/lib/ash_admin/actor_plug/plug.ex
@@ -8,24 +8,15 @@ defmodule AshAdmin.ActorPlug.Plug do
   def actor_assigns(socket, session) do
     otp_app = socket.endpoint.config(:otp_app)
     domains = domains(otp_app)
-
-    session =
-      Phoenix.LiveView.get_connect_params(socket) || session
-
-    actor_paused =
-      if is_nil(session["actor_paused"]) do
-        true
-      else
-        session_bool(session["actor_paused"])
-      end
+    session = Phoenix.LiveView.get_connect_params(socket) || session
 
     [
       actor: actor_from_session(socket.endpoint, session),
       actor_domain: actor_domain_from_session(socket.endpoint, session),
       actor_resources: actor_resources(domains),
-      authorizing: session_bool(session["actor_authorizing"]),
-      tenant: session["tenant"],
-      actor_paused: actor_paused
+      actor_paused: session_bool(session["actor_paused"], true),
+      authorizing: session_bool(session["actor_authorizing"], false),
+      tenant: session["tenant"]
     ]
   end
 
@@ -43,50 +34,34 @@ defmodule AshAdmin.ActorPlug.Plug do
       end
 
     case conn.cookies do
-      %{"actor_resource" => "undefined"} ->
+      session = %{
+        "actor_resource" => resource,
+        "actor_domain" => domain,
+        "actor_action" => action,
+        "actor_primary_key" => primary_key
+      }
+      when resource != "undefined" ->
+        actor = actor_from_session(conn.private.phoenix_endpoint, session)
+        authorizing = session_bool(session["actor_authorizing"], false)
+        actor_paused = session_bool(session["actor_paused"], true)
+
         conn
+        |> Plug.Conn.put_session(:actor_resource, resource)
+        |> Plug.Conn.put_session(:actor_domain, domain)
+        |> Plug.Conn.put_session(:actor_action, action)
+        |> Plug.Conn.put_session(:actor_primary_key, primary_key)
+        |> Plug.Conn.put_session(:actor_authorizing, authorizing)
+        |> Plug.Conn.put_session(:actor_paused, actor_paused)
+        |> Plug.Conn.assign(:actor, actor)
+        |> Plug.Conn.assign(:actor_paused, actor_paused)
+        |> Plug.Conn.assign(:authorizing, authorizing)
 
-      session ->
-        case session do
-          %{
-            "actor_resource" => resource,
-            "actor_domain" => domain,
-            "actor_action" => action,
-            "actor_primary_key" => primary_key
-          } ->
-            authorizing = session["actor_authorizing"] || false
-
-            actor_paused =
-              if is_nil(session["actor_paused"]) do
-                true
-              else
-                session["actor_paused"]
-              end
-
-            actor = actor_from_session(conn.private.phoenix_endpoint, session)
-
-            authorizing = session_bool(authorizing)
-            actor_paused = session_bool(actor_paused)
-
-            conn
-            |> Plug.Conn.put_session(:actor_resource, resource)
-            |> Plug.Conn.put_session(:actor_domain, domain)
-            |> Plug.Conn.put_session(:actor_action, action)
-            |> Plug.Conn.put_session(:actor_primary_key, primary_key)
-            |> Plug.Conn.put_session(:actor_authorizing, authorizing)
-            |> Plug.Conn.put_session(:actor_paused, actor_paused)
-            |> Plug.Conn.assign(:actor, actor)
-            |> Plug.Conn.assign(:authorizing, authorizing || false)
-            |> Plug.Conn.assign(:actor_paused, actor_paused)
-            |> Plug.Conn.assign(:authorizing, authorizing)
-
-          _ ->
-            conn
-        end
+      _ ->
+        conn
     end
   end
 
-  defp session_bool(value) do
+  defp session_bool(value, default) do
     case value do
       "true" ->
         true
@@ -101,20 +76,15 @@ defmodule AshAdmin.ActorPlug.Plug do
         boolean
 
       nil ->
-        false
+        default
     end
   end
 
   defp actor_resources(domains) do
-    domains
-    |> Enum.flat_map(fn domain ->
-      domain
-      |> Ash.Domain.Info.resources()
-      |> Enum.filter(fn resource ->
-        AshAdmin.Helpers.primary_action(resource, :read) && AshAdmin.Resource.actor?(resource)
-      end)
-      |> Enum.map(fn resource -> {domain, resource} end)
-    end)
+    for domain <- domains,
+        resource <- Ash.Domain.Info.resources(domain),
+        AshAdmin.Helpers.primary_action(resource, :read) && AshAdmin.Resource.actor?(resource),
+        do: {domain, resource}
   end
 
   defp domains(otp_app) do
@@ -124,55 +94,45 @@ defmodule AshAdmin.ActorPlug.Plug do
   end
 
   defp actor_domain_from_session(endpoint, %{"actor_domain" => domain}) do
-    otp_app = endpoint.config(:otp_app)
-    domains = Application.get_env(otp_app, :ash_domains)
-
-    Enum.find(domains, fn allowed_domain ->
-      AshAdmin.Domain.show?(allowed_domain) && AshAdmin.Domain.name(allowed_domain) == domain
-    end)
+    endpoint.config(:otp_app)
+    |> Application.get_env(:ash_domains)
+    |> Enum.find(&(AshAdmin.Domain.show?(&1) && AshAdmin.Domain.name(&1) == domain))
   end
 
   defp actor_domain_from_session(_, _), do: nil
 
-  defp actor_from_session(endpoint, %{
-         "actor_resource" => resource,
-         "actor_domain" => domain,
-         "actor_primary_key" => primary_key,
-         "actor_action" => action
-       })
+  defp actor_from_session(
+         endpoint,
+         session = %{
+           "actor_resource" => resource,
+           "actor_domain" => domain,
+           "actor_primary_key" => primary_key,
+           "actor_action" => action
+         }
+       )
        when not is_nil(resource) and not is_nil(domain) do
-    otp_app = endpoint.config(:otp_app)
-    domains = Application.get_env(otp_app, :ash_domains)
-
-    domain =
-      Enum.find(domains, fn allowed_domain ->
-        AshAdmin.Domain.show?(allowed_domain) && AshAdmin.Domain.name(allowed_domain) == domain
-      end)
+    domain = actor_domain_from_session(endpoint, session)
 
     resource =
       if domain do
         domain
         |> Ash.Domain.Info.resources()
-        |> Enum.find(fn domain_resource ->
-          AshAdmin.Resource.name(domain_resource) == resource
-        end)
+        |> Enum.find(&(AshAdmin.Resource.name(&1) == resource))
       end
 
-    if domain && resource do
-      action =
-        if action do
-          Ash.Resource.Info.action(resource, String.to_existing_atom(action), :read)
-        end
+    case resource && decode_primary_key(resource, primary_key) do
+      {:ok, filter} ->
+        action =
+          if action do
+            Ash.Resource.Info.action(resource, String.to_existing_atom(action), :read)
+          end
 
-      case decode_primary_key(resource, primary_key) do
-        :error ->
-          nil
+        resource
+        |> Ash.Query.filter(^filter)
+        |> Ash.read_one!(action: action, authorize?: false, domain: domain)
 
-        {:ok, filter} ->
-          resource
-          |> Ash.Query.filter(^filter)
-          |> Ash.read_one!(action: action, authorize?: false, domain: domain)
-      end
+      _ ->
+        nil
     end
   end
 


### PR DESCRIPTION
Starting to use ash admin. Was looking into how it plays with authorization when saw:
```elixir
|> Plug.Conn.assign(:authorizing, authorizing || false)
|> Plug.Conn.assign(:actor_paused, actor_paused)
|> Plug.Conn.assign(:authorizing, authorizing)
```
And other small things. Fixed those and end up refactoring the file.
I'm not sure that this file is actually supposed to be used by people since it has `@moduledoc false`, but anyway.

Questions:
1) What's the plan for this Plug (will get public or removed maybe)?
1) Why there is no `:ash` in formatter `import_deps`?
1) Am I right in understanding that by default all admins are equal as authorization rules do not apply to them (unless they use ability to act as some other actor)?
