### PR TITLE
fix: clear actor_tenant cookie when clearing actor

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -118,7 +118,7 @@ Hooks.Actor = {
       document.cookie = "actor_resource" + "=" + ";path=/";
       document.cookie = "actor_primary_key" + "=" + ";path=/";
       document.cookie = "actor_action" + ";path=/";
-      document.cookie = "actor_tenant" + ";path=/";
+      document.cookie = "actor_tenant" + "=" + ";path=/";
       document.cookie = "actor_domain" + "=" + ";path=/";
       document.cookie = "actor_authorizing=false;path=/";
       document.cookie = "actor_paused=true;path=/";


### PR DESCRIPTION
It looks to me that the cookie tracking `actor_tenant` added in #100 wasn't being properly cleared when clearing the actor with `clear_actor`. This PR adds a suspectedly missing `=` when setting `actor_tenant` so that the cookie is properly (?) cleared.

Maybe the same is true for the `actor_action`?

I couldn't see that this was under testing.

First code PR ever so be kind 🙏🏼

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
