### PR TITLE
WIP: #102

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -15,6 +15,7 @@ spark_locals_without_parens = [
   resource_group_labels: 1,
   show?: 1,
   show_action: 1,
+  show_resources: 1,
   show_sensitive_fields: 1,
   table_columns: 1,
   type: 1,

--- a/dev/resources/tickets/domain.ex
+++ b/dev/resources/tickets/domain.ex
@@ -5,6 +5,13 @@ defmodule Demo.Tickets.Domain do
 
   admin do
     show? true
+    show_resources [
+      Demo.Tickets.Customer,
+      Demo.Tickets.Representative,
+      Demo.Tickets.Ticket,
+      Demo.Tickets.Comment,
+      Demo.Tickets.Organization
+    ]
   end
 
   resources do

--- a/documentation/dsls/DSL:-AshAdmin.Domain.md
+++ b/documentation/dsls/DSL:-AshAdmin.Domain.md
@@ -20,6 +20,7 @@ Configure the admin dashboard for a given domain.
 |------|------|---------|------|
 | [`name`](#admin-name){: #admin-name } | `String.t` |  | The name of the domain in the dashboard. Will be derived if not set. |
 | [`show?`](#admin-show?){: #admin-show? } | `boolean` | `false` | Whether or not this domain and its resources should be included in the admin dashboard. |
+| [`show_resources`](#admin-show_resources){: #admin-show_resources } | `module` | `:*` | List of resources that should be included in the admin dashboard |
 | [`default_resource_page`](#admin-default_resource_page){: #admin-default_resource_page } | `:schema \| :primary_read` | `:schema` | Set the default page for the resource to be the primary read action or the resource schema. Schema is the default for backwards compatibility, if a resource doesn't have a primary read action it will fallback to the schema view. |
 | [`resource_group_labels`](#admin-resource_group_labels){: #admin-resource_group_labels } | `keyword` | `[]` | Humanized names for each resource group to appear in the admin area. These will be used as labels in the top navigation dropdown. If a key for a group does not appear in this mapping, the label will not be rendered. |
 

--- a/documentation/dsls/DSL:-AshAdmin.Domain.md
+++ b/documentation/dsls/DSL:-AshAdmin.Domain.md
@@ -20,7 +20,7 @@ Configure the admin dashboard for a given domain.
 |------|------|---------|------|
 | [`name`](#admin-name){: #admin-name } | `String.t` |  | The name of the domain in the dashboard. Will be derived if not set. |
 | [`show?`](#admin-show?){: #admin-show? } | `boolean` | `false` | Whether or not this domain and its resources should be included in the admin dashboard. |
-| [`show_resources`](#admin-show_resources){: #admin-show_resources } | `module` | `:*` | List of resources that should be included in the admin dashboard |
+| [`show_resources`](#admin-show_resources){: #admin-show_resources } | `list(atom) \| :*` | `:*` | List of resources that should be included in the admin dashboard |
 | [`default_resource_page`](#admin-default_resource_page){: #admin-default_resource_page } | `:schema \| :primary_read` | `:schema` | Set the default page for the resource to be the primary read action or the resource schema. Schema is the default for backwards compatibility, if a resource doesn't have a primary read action it will fallback to the schema view. |
 | [`resource_group_labels`](#admin-resource_group_labels){: #admin-resource_group_labels } | `keyword` | `[]` | Humanized names for each resource group to appear in the admin area. These will be used as labels in the top navigation dropdown. If a key for a group does not appear in this mapping, the label will not be rendered. |
 

--- a/lib/ash_admin/actor_plug/plug.ex
+++ b/lib/ash_admin/actor_plug/plug.ex
@@ -85,7 +85,7 @@ defmodule AshAdmin.ActorPlug.Plug do
 
   defp actor_resources(domains) do
     for domain <- domains,
-        resource <- Ash.Domain.Info.resources(domain),
+        resource <- AshAdmin.Domain.show_resources(domain),
         AshAdmin.Helpers.primary_action(resource, :read) && AshAdmin.Resource.actor?(resource),
         do: {domain, resource}
   end
@@ -120,7 +120,7 @@ defmodule AshAdmin.ActorPlug.Plug do
     resource =
       if domain do
         domain
-        |> Ash.Domain.Info.resources()
+        |> AshAdmin.Domain.show_resources()
         |> Enum.find(&(AshAdmin.Resource.name(&1) == resource))
       end
 

--- a/lib/ash_admin/components/top_nav.ex
+++ b/lib/ash_admin/components/top_nav.ex
@@ -143,7 +143,7 @@ defmodule AshAdmin.Components.TopNav do
   end
 
   defp dropdown_groups(prefix, current_resource, domain) do
-    for resource <- Ash.Domain.Info.resources(domain) do
+    for resource <- AshAdmin.Domain.show_resources(domain) do
       %{
         text: AshAdmin.Resource.name(resource),
         to:
@@ -180,7 +180,7 @@ defmodule AshAdmin.Components.TopNav do
   defp show_tenant_form?(domains) do
     Enum.any?(domains, fn domain ->
       domain
-      |> Ash.Domain.Info.resources()
+      |> AshAdmin.Domain.show_resources()
       |> Enum.any?(fn resource ->
         Ash.Resource.Info.multitenancy_strategy(resource)
       end)

--- a/lib/ash_admin/domain.ex
+++ b/lib/ash_admin/domain.ex
@@ -13,6 +13,11 @@ defmodule AshAdmin.Domain do
         doc:
           "Whether or not this domain and its resources should be included in the admin dashboard."
       ],
+      show_resources: [
+        type: :module,
+        default: :*,
+        doc: "List of resources that should be included in the admin dashboard"
+      ],
       default_resource_page: [
         type: {:in, [:schema, :primary_read]},
         default: :schema,
@@ -40,6 +45,13 @@ defmodule AshAdmin.Domain do
 
   def show?(domain) do
     Spark.Dsl.Extension.get_opt(domain, [:admin], :show?, false, true)
+  end
+
+  def show_resources(domain) do
+    case Spark.Dsl.Extension.get_opt(domain, [:admin], :show_resources, :*, true) do
+      :* -> Ash.Domain.Info.resources(domain)
+      resources -> resources
+    end
   end
 
   def default_resource_page(domain) do

--- a/lib/ash_admin/domain.ex
+++ b/lib/ash_admin/domain.ex
@@ -14,7 +14,7 @@ defmodule AshAdmin.Domain do
           "Whether or not this domain and its resources should be included in the admin dashboard."
       ],
       show_resources: [
-        type: :module,
+        type: {:or, [{:list, :atom}, {:literal, :*}]},
         default: :*,
         doc: "List of resources that should be included in the admin dashboard"
       ],

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -124,7 +124,7 @@ defmodule AshAdmin.PageLive do
 
   defp assign_resource(socket, resource) do
     if socket.assigns.domain do
-      resources = Ash.Domain.Info.resources(socket.assigns.domain)
+      resources = AshAdmin.Domain.show_resources(socket.assigns.domain)
 
       resource =
         Enum.find(resources, fn domain_resources ->

--- a/lib/ash_admin/resource/resource.ex
+++ b/lib/ash_admin/resource/resource.ex
@@ -194,7 +194,7 @@ defmodule AshAdmin.Resource do
 
   defp find_polymorphic_tables(resource, domains) do
     domains
-    |> Enum.flat_map(&Ash.Domain.Info.resources/1)
+    |> Enum.flat_map(&AshAdmin.Domain.show_resources/1)
     |> Enum.flat_map(&Ash.Resource.Info.relationships/1)
     |> Enum.filter(&(&1.destination == resource))
     |> Enum.map(& &1.context[:data_layer][:table])


### PR DESCRIPTION
Main questions:
- type for show_resources: `{:or, [{:list, :atom}, {:literal, :*}]}`. *I would much rather have it limited to not any :array, but only resources actually presented in current domain, but i have no idea how to validate it.*
- I have introduced `&AshAdmin.Domain.show_resources/1` which based on domain config returns either all resources for domain or only allowed ones. I use this function in 6 places. It might be too excessive and in some places it might be better to leave access to all domain resources. So question is *Should this task limit available resources only in top nav or globally in admin panel?*
- currently i have not written any tests. *Should i add it to `page_live_tests.exs`* Based on previous question scope can change, and amount of tests also would change.

This is more like initial draft, feel free to point out the good, the bad, the ugly.