### PR TITLE
Update getting-started-with-ash-admin.md

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-admin.md
+++ b/documentation/tutorials/getting-started-with-ash-admin.md
@@ -99,4 +99,24 @@ This will allow AshAdmin-generated inline CSS and JS blocks to execute normally.
 
 ## Troubleshooting
 
+#### UI issues
 If your admin UI is not responding as expected, check your browser's developer console for content-security-policy violations (see above).
+
+#### Router issues
+If you are seeing the following error `(UndefinedFunctionError) function YourAppWeb.AshAdmin.PageLive.__live__/0 is undefined (module YourAppWeb.AshAdmin.PageLive is not available)` it likely means that you added the ash admin route macro under a scope with a prefix. Make sure that you add it under a scope without any prefixes.
+
+```elixir
+  # Incorrect (with YourAppWeb prefix)
+  scope "/", YourAppWeb do
+    pipe_through [:browser]
+
+    ash_admin "/admin"
+  end
+
+  # Correct (without prefix)
+  scope "/", YourAppWeb do
+    pipe_through [:browser]
+
+    ash_admin "/admin"
+  end
+```

--- a/documentation/tutorials/getting-started-with-ash-admin.md
+++ b/documentation/tutorials/getting-started-with-ash-admin.md
@@ -114,7 +114,7 @@ If you are seeing the following error `(UndefinedFunctionError) function YourApp
   end
 
   # Correct (without prefix)
-  scope "/", YourAppWeb do
+  scope "/" do
     pipe_through [:browser]
 
     ash_admin "/admin"


### PR DESCRIPTION
It seems people often get confused by adding the `ash_admin/2` routes to a prefixed scope. We can include this "gotcha" in there installation docs to reduce friction.

Example issue in forums https://elixirforum.com/t/ash-admin-missing-pagelive-live/58567

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

We only update docs so none of the checklists apply.

