### PR TITLE
feat: Sort resource_group_labels by given order

### DIFF
--- a/documentation/dsls/DSL-AshAdmin.Domain.md
+++ b/documentation/dsls/DSL-AshAdmin.Domain.md
@@ -22,7 +22,7 @@ Configure the admin dashboard for a given domain.
 | [`show?`](#admin-show?){: #admin-show? } | `boolean` | `false` | Whether or not this domain and its resources should be included in the admin dashboard. |
 | [`show_resources`](#admin-show_resources){: #admin-show_resources } | `atom \| list(atom)` | `:*` | List of resources that should be included in the admin dashboard |
 | [`default_resource_page`](#admin-default_resource_page){: #admin-default_resource_page } | `:schema \| :primary_read` | `:schema` | Set the default page for the resource to be the primary read action or the resource schema. Schema is the default for backwards compatibility, if a resource doesn't have a primary read action it will fallback to the schema view. |
-| [`resource_group_labels`](#admin-resource_group_labels){: #admin-resource_group_labels } | `keyword` | `[]` | Humanized names for each resource group to appear in the admin area. These will be used as labels in the top navigation dropdown. If a key for a group does not appear in this mapping, the label will not be rendered. |
+| [`resource_group_labels`](#admin-resource_group_labels){: #admin-resource_group_labels } | `keyword` | `[]` | Humanized names for each resource group to appear in the admin area. These will be used as labels in the top navigation dropdown and will be shown sorted as given. If a key for a group does not appear in this mapping, the label will not be rendered. |
 
 
 

--- a/lib/ash_admin/components/top_nav.ex
+++ b/lib/ash_admin/components/top_nav.ex
@@ -2,7 +2,14 @@ defmodule AshAdmin.Components.TopNav do
   @moduledoc false
   use Phoenix.LiveComponent
   import AshAdmin.Helpers
-  alias AshAdmin.Components.TopNav.{ActorSelect, DrawerDropdown, Dropdown, TenantForm}
+
+  alias AshAdmin.Components.TopNav.{
+    ActorSelect,
+    DrawerDropdown,
+    Dropdown,
+    DropdownHelper,
+    TenantForm
+  }
 
   attr :domain, :any, required: true
   attr :resource, :any, required: true
@@ -44,8 +51,8 @@ defmodule AshAdmin.Components.TopNav do
                     class="mr-1"
                     id={AshAdmin.Domain.name(domain) <> "_domain_nav"}
                     name={AshAdmin.Domain.name(domain)}
-                    groups={dropdown_groups(@prefix, @resource, domain)}
-                    group_labels={dropdown_group_labels(domain)}
+                    groups={DropdownHelper.dropdown_groups(@prefix, @resource, domain)}
+                    group_labels={DropdownHelper.dropdown_group_labels(domain)}
                   />
                 </div>
                 <div class="ml-10 flex items-center">
@@ -132,32 +139,13 @@ defmodule AshAdmin.Components.TopNav do
             module={DrawerDropdown}
             id={AshAdmin.Domain.name(domain) <> "_domain_nav_drawer"}
             name={AshAdmin.Domain.name(domain)}
-            groups={dropdown_groups(@prefix, @resource, domain)}
-            group_labels={dropdown_group_labels(domain)}
+            groups={DropdownHelper.dropdown_groups(@prefix, @resource, domain)}
+            group_labels={DropdownHelper.dropdown_group_labels(domain)}
           />
         </div>
       </div>
     </nav>
     """
-  end
-
-  defp dropdown_groups(prefix, current_resource, domain) do
-    for resource <- AshAdmin.Domain.show_resources(domain) do
-      %{
-        text: AshAdmin.Resource.name(resource),
-        to:
-          "#{prefix}?domain=#{AshAdmin.Domain.name(domain)}&resource=#{AshAdmin.Resource.name(resource)}",
-        active: resource == current_resource,
-        group: AshAdmin.Resource.resource_group(resource)
-      }
-    end
-    |> Enum.group_by(fn resource -> resource.group end)
-    |> Enum.sort_by(fn {label, _items} -> label || "_____always_put_me_last" end)
-    |> Keyword.values()
-  end
-
-  defp dropdown_group_labels(domain) do
-    AshAdmin.Domain.resource_group_labels(domain)
   end
 
   def mount(socket) do

--- a/lib/ash_admin/components/top_nav/helpers/dropdown_helper.ex
+++ b/lib/ash_admin/components/top_nav/helpers/dropdown_helper.ex
@@ -12,8 +12,12 @@ defmodule AshAdmin.Components.TopNav.DropdownHelper do
       }
     end
     |> Enum.group_by(fn resource -> resource.group end)
-    |> Enum.sort_by(fn {label, _items} -> label || "_____always_put_me_last" end)
-    |> Keyword.values()
+    |> Enum.with_index()
+    |> Enum.sort_by(fn
+      {{nil, _links}, _index} -> {1, nil}
+      {{_group, _links}, index} -> {0, index}
+    end)
+    |> Enum.map(fn {{_group, links}, _index} -> links end)
   end
 
   def dropdown_group_labels(domain) do

--- a/lib/ash_admin/components/top_nav/helpers/dropdown_helper.ex
+++ b/lib/ash_admin/components/top_nav/helpers/dropdown_helper.ex
@@ -1,0 +1,22 @@
+defmodule AshAdmin.Components.TopNav.DropdownHelper do
+  @moduledoc false
+
+  def dropdown_groups(prefix, current_resource, domain) do
+    for resource <- AshAdmin.Domain.show_resources(domain) do
+      %{
+        text: AshAdmin.Resource.name(resource),
+        to:
+          "#{prefix}?domain=#{AshAdmin.Domain.name(domain)}&resource=#{AshAdmin.Resource.name(resource)}",
+        active: resource == current_resource,
+        group: AshAdmin.Resource.resource_group(resource)
+      }
+    end
+    |> Enum.group_by(fn resource -> resource.group end)
+    |> Enum.sort_by(fn {label, _items} -> label || "_____always_put_me_last" end)
+    |> Keyword.values()
+  end
+
+  def dropdown_group_labels(domain) do
+    AshAdmin.Domain.resource_group_labels(domain)
+  end
+end

--- a/lib/ash_admin/domain.ex
+++ b/lib/ash_admin/domain.ex
@@ -28,7 +28,7 @@ defmodule AshAdmin.Domain do
         type: :keyword_list,
         default: [],
         doc:
-          "Humanized names for each resource group to appear in the admin area. These will be used as labels in the top navigation dropdown. If a key for a group does not appear in this mapping, the label will not be rendered."
+          "Humanized names for each resource group to appear in the admin area. These will be used as labels in the top navigation dropdown and will be shown sorted as given. If a key for a group does not appear in this mapping, the label will not be rendered."
       ]
     ]
   }

--- a/test/components/top_nav/helpers/dropdown_helper_test.exs
+++ b/test/components/top_nav/helpers/dropdown_helper_test.exs
@@ -1,0 +1,44 @@
+defmodule AshAdmin.Test.Components.TopNav.Helpers.DropdownHelperTest do
+  use ExUnit.Case, async: true
+
+  alias AshAdmin.Components.TopNav.DropdownHelper
+
+  describe "dropdown_groups/3" do
+    test "groups resources" do
+      prefix = "/admin"
+      current_resource = AshAdmin.Test.Post
+      domain = AshAdmin.Test.Domain
+
+      post_link = %{
+        active: true,
+        group: nil,
+        text: "Post",
+        to: "/admin?domain=Test&resource=Post"
+      }
+
+      comment_link = %{
+        active: false,
+        group: nil,
+        text: "Comment",
+        to: "/admin?domain=Test&resource=Comment"
+      }
+
+      assert_unordered(
+        [[post_link, comment_link]],
+        DropdownHelper.dropdown_groups(prefix, current_resource, domain)
+      )
+    end
+  end
+
+  describe "dropdown_group_labels/1" do
+    test "returns groups" do
+      domain = AshAdmin.Test.Domain
+
+      assert [] = DropdownHelper.dropdown_group_labels(domain)
+    end
+  end
+
+  defp assert_unordered(enum, other_enum) do
+    assert MapSet.new(enum) == MapSet.new(other_enum)
+  end
+end

--- a/test/components/top_nav/helpers/dropdown_helper_test.exs
+++ b/test/components/top_nav/helpers/dropdown_helper_test.exs
@@ -9,9 +9,16 @@ defmodule AshAdmin.Test.Components.TopNav.Helpers.DropdownHelperTest do
       current_resource = AshAdmin.Test.Post
       domain = AshAdmin.Test.Domain
 
+      blog_link = %{
+        active: false,
+        group: :group_b,
+        text: "Blog",
+        to: "/admin?domain=Test&resource=Blog"
+      }
+
       post_link = %{
         active: true,
-        group: nil,
+        group: :group_a,
         text: "Post",
         to: "/admin?domain=Test&resource=Post"
       }
@@ -24,17 +31,30 @@ defmodule AshAdmin.Test.Components.TopNav.Helpers.DropdownHelperTest do
       }
 
       assert_unordered(
-        [[post_link, comment_link]],
+        [[blog_link], [comment_link], [post_link]],
         DropdownHelper.dropdown_groups(prefix, current_resource, domain)
       )
     end
+
+    test "groups resources by given order from the domain" do
+      prefix = "/admin"
+      current_resource = AshAdmin.Test.Post
+      domain = AshAdmin.Test.Domain
+
+      assert [
+               [%{group: :group_b, text: "Blog"} = _blog_link],
+               [%{group: :group_a, text: "Post"} = _post_link],
+               [%{group: nil, text: "Comment"} = _comment_link]
+             ] = DropdownHelper.dropdown_groups(prefix, current_resource, domain)
+    end
   end
 
-  describe "dropdown_group_labels/1" do
+  describe "dropdown_group_labels/3" do
     test "returns groups" do
       domain = AshAdmin.Test.Domain
 
-      assert [] = DropdownHelper.dropdown_group_labels(domain)
+      assert [group_b: "Group B", group_a: "Group A", group_c: "Group C"] =
+               DropdownHelper.dropdown_group_labels(domain)
     end
   end
 

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -5,9 +5,11 @@ defmodule AshAdmin.Test.Domain do
 
   admin do
     show? true
+    resource_group_labels group_b: "Group B", group_a: "Group A", group_c: "Group C"
   end
 
   resources do
+    resource(AshAdmin.Test.Blog)
     resource(AshAdmin.Test.Post)
     resource(AshAdmin.Test.Comment)
   end

--- a/test/support/resources/blog.ex
+++ b/test/support/resources/blog.ex
@@ -1,4 +1,4 @@
-defmodule AshAdmin.Test.Post do
+defmodule AshAdmin.Test.Blog do
   @moduledoc false
   use Ash.Resource,
     domain: AshAdmin.Test.Domain,
@@ -15,6 +15,6 @@ defmodule AshAdmin.Test.Post do
   end
 
   admin do
-    resource_group(:group_a)
+    resource_group(:group_b)
   end
 end


### PR DESCRIPTION
Let's say, we have this in a domain:
```elixir
admin do
  show? true
  resource_group_labels group_b: "Group B", group_a: "Group A", group_c: "Group C"
end
``` 

Currently, `resource_group_labels` shows labels in ascending alphabetical order and this will result to this in the domain dropdown:

- Group A
- Group B
- Group C
- (resources without group)

This PR let `resource_group_labels` to strictly sort labels as given and this will be the result in the domain dropdown:

- Group B
- Group A
- Group C
- (resources without group)

The reason is that when I tried `ash_admin` with `ash_paper_trail`, I tried to group all resources with `Version` in a group called `Audit log` which starts with an `A`. There is another group called `Domain`. As result, `Audit log` group is always at the top and I wanted to actually put this group under the `Domain` group.

Follow up to https://github.com/ash-project/ash_admin/pull/15

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
