### PR TITLE
chore: Fix warnings related to params of AshPhoenix.Form.submit

### DIFF
--- a/lib/ash_admin/components/resource/data_table.ex
+++ b/lib/ash_admin/components/resource/data_table.ex
@@ -203,7 +203,10 @@ defmodule AshAdmin.Components.Resource.DataTable do
                 []
               end
 
-            case AshPhoenix.Form.submit(socket.assigns.query, action_opts: action_opts) do
+            case AshPhoenix.Form.submit(socket.assigns.query,
+                   action_opts: action_opts,
+                   params: nil
+                 ) do
               {:ok, data} -> assign(socket, :data, {:ok, data})
               {:error, query} -> assign(socket, data: {:error, all_errors(query)}, query: query)
             end

--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -1657,7 +1657,7 @@ defmodule AshAdmin.Components.Resource.Form do
      |> assign(:form, form)}
   end
 
-  def handle_event("save", _, socket) do
+  def handle_event("save", %{"form" => form_params}, socket) do
     form = socket.assigns.form
 
     before_submit = fn changeset ->
@@ -1666,7 +1666,11 @@ defmodule AshAdmin.Components.Resource.Form do
       |> Map.put(:actor, socket.assigns[:actor])
     end
 
-    case AshPhoenix.Form.submit(form, before_submit: before_submit, force?: true) do
+    case AshPhoenix.Form.submit(form,
+           before_submit: before_submit,
+           force?: true,
+           params: form_params
+         ) do
       {:ok, result} ->
         redirect_to(socket, result)
 

--- a/lib/ash_admin/components/resource/generic_action.ex
+++ b/lib/ash_admin/components/resource/generic_action.ex
@@ -309,7 +309,7 @@ defmodule AshAdmin.Components.Resource.GenericAction do
     #             []
     #           end
 
-    #         case AshPhoenix.Form.submit(socket.assigns.query, action_opts: action_opts) do
+    #         case AshPhoenix.Form.submit(socket.assigns.query, action_opts: action_opts, params: nil) do
     #           {:ok, data} -> assign(socket, :data, {:ok, data})
     #           {:error, query} -> assign(socket, data: {:error, all_errors(query)}, query: query)
     #         end


### PR DESCRIPTION
This PR removes warnings related to `params` of `AshPhoenix.Form.submit`:

As reminder, the warning was the following:
```elixir
warning: The `params` option should be supplied at all times. This will be required in a future major release.
To silence this warning without providing `params`, you can pass `params: nil`.

For example:

    def handle_event("submit", %{"form" => params}, socket) do
      case AshPhoenix.Form.submit(socket.assigns.form, params: params) do
        ...
      end
    end
``` 

The form unassigned parameters are given to `AshPhoenix.Form.submit` when possible, otherwise `params: nil` is given.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
