### PR TITLE
fix(Calculations): Show form when calculation doesn't have arguments

### DIFF
--- a/dev/resources/accounts/resources/user.ex
+++ b/dev/resources/accounts/resources/user.ex
@@ -21,7 +21,7 @@ defmodule Demo.Accounts.User do
 
     table_columns [:id, :first_name, :last_name, :representative, :admin, :full_name, :api_key, :date_of_birth]
 
-    show_calculations [:multi_arguments, :full_name]
+    show_calculations [:multi_arguments, :is_super_admin?, :full_name, :nested_embed]
   end
 
   multitenancy do
@@ -106,6 +106,10 @@ defmodule Demo.Accounts.User do
         allow_nil? true
       end
     end
+
+    calculate :nested_embed, :string, expr(tags) do
+      argument :nested_embed, Demo.Accounts.NestedEmbed, allow_nil?: false
+    end
   end
 
   attributes do
@@ -170,6 +174,7 @@ defmodule Demo.Accounts.User do
       public? true
       constraints items: [one_of: [:type1, :type2]]
     end
+
     attribute :tags, {:array, :string} do
       public? true
     end

--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -1155,6 +1155,8 @@ defmodule AshAdmin.Components.Resource.Form do
                 name: @name || @form.name <> "[#{@attribute.name}]"
             }
           )}
+        <% Ash.Type.embedded_type?(@attribute.type) && match?(%{source: %AshPhoenix.FilterForm.Arguments{}}, @form) -> %>
+          {"AshPhoenix.FilterForm doesn't support embedded yet"}
         <% Ash.Type.embedded_type?(@attribute.type) -> %>
           <.inputs_for :let={inner_form} field={@form[@attribute.name]}>
             <.input

--- a/lib/ash_admin/components/resource/show.ex
+++ b/lib/ash_admin/components/resource/show.ex
@@ -104,7 +104,6 @@ defmodule AshAdmin.Components.Resource.Show do
         <div>
           <.form
             :let={form}
-            :if={!Enum.empty?(calculation.arguments)}
             as={calculation.name}
             for={calculation_form}
             phx-change="validate-calculation"


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests


This PR has 2 fixes:
- Show calculation form even when calcuation doesn't have arguments, we are no preload any calculation, because that we should show at least the calculate button to load it
- Show warning message on embedded calculation's argument, until we don't support embedded type on `FilterForm` (see here https://github.com/ash-project/ash_phoenix/blob/v2.1.9/lib/ash_phoenix/filter_form/filter_form.ex#L1246) I think should be good to at least show this warning, what do you think?