### PR TITLE
fix(PhoenixLiveView): remove phx-feedback-for and fix unsued params

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -22,9 +22,6 @@ module.exports = {
     //     <div class="phx-click-loading:animate-ping">
     //
     plugin(({ addVariant }) =>
-      addVariant("phx-no-feedback", [".phx-no-feedback&", ".phx-no-feedback &"])
-    ),
-    plugin(({ addVariant }) =>
       addVariant("phx-click-loading", [
         ".phx-click-loading&",
         ".phx-click-loading &",

--- a/lib/ash_admin/components/core_components.ex
+++ b/lib/ash_admin/components/core_components.ex
@@ -287,9 +287,11 @@ defmodule AshAdmin.CoreComponents do
   slot :inner_block
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
-    |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
+    |> assign(:errors, Enum.map(errors, &translate_error(&1)))
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
     |> input()
@@ -300,7 +302,7 @@ defmodule AshAdmin.CoreComponents do
       assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", value) end)
 
     ~H"""
-    <div phx-feedback-for={@name}>
+    <div>
       <label class="flex items-center gap-4 text-sm leading-6 text-zinc-600">
         <input type="hidden" name={@name} value="false" />
         <input
@@ -321,7 +323,7 @@ defmodule AshAdmin.CoreComponents do
 
   def input(%{type: "select"} = assigns) do
     ~H"""
-    <div phx-feedback-for={@name}>
+    <div>
       <.label for={@id}>{@label}</.label>
       <select
         id={@id}
@@ -340,14 +342,13 @@ defmodule AshAdmin.CoreComponents do
 
   def input(%{type: "textarea"} = assigns) do
     ~H"""
-    <div phx-feedback-for={@name}>
+    <div>
       <.label for={@id}>{@label}</.label>
       <textarea
         id={@id}
         name={@name}
         class={[
-          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
-          "min-h-[6rem] phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6 min-h-[6rem]",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
           @errors != [] && "border-rose-400 focus:border-rose-400"
         ]}
@@ -361,7 +362,7 @@ defmodule AshAdmin.CoreComponents do
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
     ~H"""
-    <div phx-feedback-for={@name}>
+    <div>
       <.label for={@id}>{@label}</.label>
       <input
         type={@type}
@@ -370,7 +371,6 @@ defmodule AshAdmin.CoreComponents do
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
           "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
-          "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
           @errors != [] && "border-rose-400 focus:border-rose-400"
         ]}
@@ -402,7 +402,7 @@ defmodule AshAdmin.CoreComponents do
 
   def error(assigns) do
     ~H"""
-    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600 phx-no-feedback:hidden">
+    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600">
       <.icon name="hero-exclamation-circle-mini" class="mt-0.5 h-5 w-5 flex-none" />
       {render_slot(@inner_block)}
     </p>

--- a/mix.exs
+++ b/mix.exs
@@ -120,7 +120,7 @@ defmodule AshAdmin.MixProject do
       {:phoenix_view, "~> 2.0"},
       {:phoenix, "~> 1.7"},
       {:phoenix_live_view, "~> 1.0"},
-      {:phoenix_html, "~> 4.0"},
+      {:phoenix_html, "~> 4.1"},
       {:jason, "~> 1.0"},
       {:gettext, "~> 0.26"},
       # Dev dependencies

--- a/priv/static/assets/app.css
+++ b/priv/static/assets/app.css
@@ -2153,34 +2153,6 @@ select {
   opacity: 0.7;
 }
 
-.phx-no-feedback.phx-no-feedback\:hidden {
-  display: none;
-}
-
-.phx-no-feedback.phx-no-feedback\:border-zinc-300 {
-  --tw-border-opacity: 1;
-  border-color: rgb(212 212 216 / var(--tw-border-opacity));
-}
-
-.phx-no-feedback.phx-no-feedback\:focus\:border-zinc-400:focus {
-  --tw-border-opacity: 1;
-  border-color: rgb(161 161 170 / var(--tw-border-opacity));
-}
-
-.phx-no-feedback .phx-no-feedback\:hidden {
-  display: none;
-}
-
-.phx-no-feedback .phx-no-feedback\:border-zinc-300 {
-  --tw-border-opacity: 1;
-  border-color: rgb(212 212 216 / var(--tw-border-opacity));
-}
-
-.phx-no-feedback .phx-no-feedback\:focus\:border-zinc-400:focus {
-  --tw-border-opacity: 1;
-  border-color: rgb(161 161 170 / var(--tw-border-opacity));
-}
-
 .phx-submit-loading.phx-submit-loading\:opacity-75 {
   opacity: 0.75;
 }

--- a/priv/static/assets/app.js
+++ b/priv/static/assets/app.js
@@ -6308,7 +6308,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     }
     // public
     version() {
-      return "1.0.0";
+      return "1.0.1";
     }
     isProfileEnabled() {
       return this.sessionStorage.getItem(PHX_LV_PROFILE) === "true";


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests


I removed `phx-feedback-for` and replace to `Phoenix.Component.used_input?`, see more here https://github.com/phoenixframework/phoenix_live_view/blob/main/CHANGELOG.md

I tried to filter the unsued params from `list_value/1` or `render_fallback_attribute/7` but I wasn't able to do it, because the form is been updated on `AshPhoenix.Form.validate/3` before we receive the attributes.

The only solution I got is filtering the params before validate it or updating `ash_phoenix` to handle `_unsued_*`

I will keep it as draft until we got a better solution 