### PR TITLE
fix(UnsuedParams): Filter nil values

### DIFF
--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -1797,7 +1797,9 @@ defmodule AshAdmin.Components.Resource.Form do
   end
 
   defp replace_unused(params) when is_map(params) do
-    Map.new(params, &replace_unused/1)
+    Map.to_list(params)
+    |> replace_unused()
+    |> Map.new()
   end
 
   defp replace_unused(params) when is_list(params) do


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests


We can't use `Map.new/2` on `replace_unused/1` because we must remove the `_unused_*` attributes