### PR TITLE
Add security section to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 Welcome! This is a super-admin UI dashboard for [Ash Framework](https://hexdocs.pm/ash) applications, built with Phoenix LiveView.
 
-If you are using Phoenix LiveView 1.0.0 release candidate, you will need to use the live_view_1.0 branch of this repo.
-
 ## Tutorials
 
 - [Getting Started with AshAdmin](documentation/tutorials/getting-started-with-ash-admin.md)


### PR DESCRIPTION
Security tutorial added, based on Zach's reply to this thread:
https://elixirforum.com/t/ash-admin-inside-ash-authenticated-live-session/65213/3

I'm not sure if this is still the recommended way, but it didn't seem the ash_admin macro is compatible with the ash_authentication_live_session macro so I assume it is; please do correct me if I'm wrong :))

A line was also removed from README.md, asking users to use different ash_admin branch with LiveView >= 1.0