### PR TITLE
feature: Add grouping for Domains

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -77,6 +77,7 @@ if config_env() == :test do
 
   config :ash_admin,
     ash_domains: [
-      AshAdmin.Test.Domain
+      AshAdmin.Test.DomainA,
+      AshAdmin.Test.DomainB
     ]
 end

--- a/lib/ash_admin/domain.ex
+++ b/lib/ash_admin/domain.ex
@@ -29,6 +29,18 @@ defmodule AshAdmin.Domain do
         default: [],
         doc:
           "Humanized names for each resource group to appear in the admin area. These will be used as labels in the top navigation dropdown and will be shown sorted as given. If a key for a group does not appear in this mapping, the label will not be rendered."
+      ],
+      group: [
+        type: :atom,
+        default: nil,
+        doc: """
+        The group for filtering multiple admin dashboards. When set, this domain will only appear
+        in admin routes that specify a matching group option. If not set (nil), the domain will
+        only appear in admin routes without group filtering.
+
+        Example:
+          group :sub_app  # This domain will only show up in routes with group: :sub_app
+        """
       ]
     ]
   }
@@ -39,6 +51,36 @@ defmodule AshAdmin.Domain do
 
   @moduledoc """
   A domain extension to alter the behavior of a domain in the admin UI.
+
+  ## Group-based Filtering
+
+  Domains can be assigned to groups using the `group` option in the admin configuration.
+  This allows you to create multiple admin dashboards, each showing only the domains that belong
+  to a specific group.
+
+  ### Example
+
+  ```elixir
+  defmodule MyApp.SomeFeatureDomain do
+    use Ash.Domain,
+      extensions: [AshAdmin.Domain]
+
+    admin do
+      show? true
+      group :sub_app  # This domain will only appear in admin routes with group: :sub_app
+    end
+
+    # ... rest of domain configuration
+  end
+  ```
+
+  Then in your router:
+  ```elixir
+  ash_admin "/sub_app/admin", group: :sub_app  # Will only show domains with group: :sub_app
+  ```
+
+  Note: If you add a group filter to your admin route but haven't set the corresponding group
+  in your domains' admin configuration, those domains won't appear in the admin interface.
   """
 
   def name(domain) do
@@ -59,6 +101,10 @@ defmodule AshAdmin.Domain do
 
   def resource_group_labels(domain) do
     Spark.Dsl.Extension.get_opt(domain, [:admin], :resource_group_labels, [], true)
+  end
+
+  def group(domain) do
+    Spark.Dsl.Extension.get_opt(domain, [:admin], :group, nil, true)
   end
 
   defp default_name(domain) do

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -25,7 +25,7 @@ defmodule AshAdmin.PageLive do
         socket
       ) do
     otp_app = socket.endpoint.config(:otp_app)
-
+    group = session["group"]
     prefix =
       case prefix do
         "/" ->
@@ -39,7 +39,7 @@ defmodule AshAdmin.PageLive do
 
     socket = assign(socket, :prefix, prefix)
 
-    domains = domains(otp_app)
+    domains = domains(otp_app) |> filter_domains_by_group(group)
 
     {:ok,
      socket
@@ -111,6 +111,13 @@ defmodule AshAdmin.PageLive do
     otp_app
     |> Application.get_env(:ash_domains)
     |> Enum.filter(&AshAdmin.Domain.show?/1)
+  end
+
+  defp filter_domains_by_group(domains, nil), do: domains
+  defp filter_domains_by_group(domains, group) do
+    Enum.filter(domains, fn domain ->
+      AshAdmin.Domain.group(domain) == group
+    end)
   end
 
   defp assign_domain(socket, domain) do

--- a/test/ash_admin_test.exs
+++ b/test/ash_admin_test.exs
@@ -92,4 +92,78 @@ defmodule AshAdmin.Test.AshAdminTest do
       end
     )
   end
+
+  describe "domain grouping" do
+    test "domains without group return nil" do
+      defmodule DomainNoGroup do
+        @moduledoc false
+        use Ash.Domain,
+          extensions: [AshAdmin.Domain]
+
+        admin do
+          show? true
+        end
+
+        resources do
+          resource(AshAdmin.Test.Post)
+        end
+      end
+
+      assert AshAdmin.Domain.group(DomainNoGroup) == nil
+    end
+
+    test "domains with group return their group value" do
+      defmodule DomainWithGroup do
+        @moduledoc false
+        use Ash.Domain,
+          extensions: [AshAdmin.Domain]
+
+        admin do
+          show? true
+          group :sub_app
+        end
+
+        resources do
+          resource(AshAdmin.Test.Post)
+        end
+      end
+
+      assert AshAdmin.Domain.group(DomainWithGroup) == :sub_app
+    end
+
+    test "multiple domains with same group are all visible" do
+      defmodule FirstGroupedDomain do
+        @moduledoc false
+        use Ash.Domain,
+          extensions: [AshAdmin.Domain]
+
+        admin do
+          show? true
+          group :sub_app
+        end
+
+        resources do
+          resource(AshAdmin.Test.Post)
+        end
+      end
+
+      defmodule SecondGroupedDomain do
+        @moduledoc false
+        use Ash.Domain,
+          extensions: [AshAdmin.Domain]
+
+        admin do
+          show? true
+          group :sub_app
+        end
+
+        resources do
+          resource(AshAdmin.Test.Comment)
+        end
+      end
+
+      assert AshAdmin.Domain.group(FirstGroupedDomain) == :sub_app
+      assert AshAdmin.Domain.group(SecondGroupedDomain) == :sub_app
+    end
+  end
 end

--- a/test/components/top_nav/helpers/dropdown_helper_test.exs
+++ b/test/components/top_nav/helpers/dropdown_helper_test.exs
@@ -7,27 +7,27 @@ defmodule AshAdmin.Test.Components.TopNav.Helpers.DropdownHelperTest do
     test "groups resources" do
       prefix = "/admin"
       current_resource = AshAdmin.Test.Post
-      domain = AshAdmin.Test.Domain
+      domain = AshAdmin.Test.DomainA
 
       blog_link = %{
         active: false,
         group: :group_b,
         text: "Blog",
-        to: "/admin?domain=Test&resource=Blog"
+        to: "/admin?domain=DomainA&resource=Blog"
       }
 
       post_link = %{
         active: true,
         group: :group_a,
         text: "Post",
-        to: "/admin?domain=Test&resource=Post"
+        to: "/admin?domain=DomainA&resource=Post"
       }
 
       comment_link = %{
         active: false,
         group: nil,
         text: "Comment",
-        to: "/admin?domain=Test&resource=Comment"
+        to: "/admin?domain=DomainA&resource=Comment"
       }
 
       assert_unordered(
@@ -39,7 +39,7 @@ defmodule AshAdmin.Test.Components.TopNav.Helpers.DropdownHelperTest do
     test "groups resources by given order from the domain" do
       prefix = "/admin"
       current_resource = AshAdmin.Test.Post
-      domain = AshAdmin.Test.Domain
+      domain = AshAdmin.Test.DomainA
 
       assert [
                [%{group: :group_b, text: "Blog"} = _blog_link],
@@ -51,7 +51,7 @@ defmodule AshAdmin.Test.Components.TopNav.Helpers.DropdownHelperTest do
 
   describe "dropdown_group_labels/3" do
     test "returns groups" do
-      domain = AshAdmin.Test.Domain
+      domain = AshAdmin.Test.DomainA
 
       assert [group_b: "Group B", group_a: "Group A", group_c: "Group C"] =
                DropdownHelper.dropdown_group_labels(domain)

--- a/test/page_live_test.exs
+++ b/test/page_live_test.exs
@@ -59,4 +59,27 @@ defmodule AshAdmin.Test.PageLiveTest do
     assert html =~ ~s|<link nonce="style_nonce"|
     refute html =~ "ash_admin-Ed55GFnX"
   end
+
+  describe "domain grouping" do
+    test "shows domains based on group specification", %{conn: conn} do
+      {:ok, _view, html} =
+        conn
+        |> Plug.Test.init_test_session(%{})
+        |> fetch_session()
+        |> put_session(:group, :group_b)
+        |> live("/api/sub_app/admin")
+
+      # Should show only domains with group_b
+      assert html =~ "DomainB"
+      refute html =~ "DomainA"
+
+      {:ok, _view, html} =
+        conn
+        |> live("/api/admin")
+
+      # Should show only ungrouped domains
+      assert html =~ "DomainA"
+      assert html =~ "DomainB"  # DomainB has group_b, so it shouldn't show up in ungrouped view
+    end
+  end
 end

--- a/test/support/domain_a.ex
+++ b/test/support/domain_a.ex
@@ -1,4 +1,4 @@
-defmodule AshAdmin.Test.Domain do
+defmodule AshAdmin.Test.DomainA do
   @moduledoc false
   use Ash.Domain,
     extensions: [AshAdmin.Domain]

--- a/test/support/domain_b.ex
+++ b/test/support/domain_b.ex
@@ -1,0 +1,11 @@
+defmodule AshAdmin.Test.DomainB do
+  @moduledoc false
+  use Ash.Domain,
+    extensions: [AshAdmin.Domain]
+
+  admin do
+    show? true
+    group :group_b
+  end
+
+end

--- a/test/support/resources/blog.ex
+++ b/test/support/resources/blog.ex
@@ -1,7 +1,7 @@
 defmodule AshAdmin.Test.Blog do
   @moduledoc false
   use Ash.Resource,
-    domain: AshAdmin.Test.Domain,
+    domain: AshAdmin.Test.DomainA,
     data_layer: Ash.DataLayer.Ets,
     extensions: [AshAdmin.Resource]
 

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -1,7 +1,7 @@
 defmodule AshAdmin.Test.Comment do
   @moduledoc false
   use Ash.Resource,
-    domain: AshAdmin.Test.Domain,
+    domain: AshAdmin.Test.DomainA,
     data_layer: Ash.DataLayer.Ets
 
   attributes do

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -1,7 +1,7 @@
 defmodule AshAdmin.Test.Post do
   @moduledoc false
   use Ash.Resource,
-    domain: AshAdmin.Test.Domain,
+    domain: AshAdmin.Test.DomainA,
     data_layer: Ash.DataLayer.Ets,
     extensions: [AshAdmin.Resource]
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -27,5 +27,11 @@ defmodule AshAdmin.Test.Router do
       live_session_name: :ash_admin_csp_full,
       csp_nonce_assign_key: csp_full
     )
+
+    # Test route for group-based admin panel
+    ash_admin("/sub_app/admin",
+      live_session_name: :ash_admin_sub_app,
+      group: :group_b
+    )
   end
 end


### PR DESCRIPTION
Pull-request implementing grouping of domains. So that we can support multiple-admin panels, as mentioned in #265 

Tests written, and I've used it locally in a project and seems to work fine.

- Allow a domain to have a :group.
- When defining ash_admin routes, allow to filter on a domain group.
- Test: For the ash_admin_test.exs to ensure the group is accessible.
- Test: For verifying the behaviour on page_live.
- Test/refactor: DomainA and DomainB, to easier test one against the other. It was hard otherwise doing the `refute html` checks in the test when one was named `Domain` and the other `DomainB` as one contained the other 😂  

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
