### PR TITLE
fix generate_migrations alias

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -77,7 +77,7 @@ defmodule AshAdmin.MixProject do
   defp aliases() do
     [
       generate_migrations:
-        "ash_postgres.generate_migrations --domains Demo.Accounts.Domain,Demo.Tickets.Domain --snapshot-path dev/resource_snapshots --migration-path dev --drop-columns",
+        "ash_postgres.generate_migrations --domains Demo.Accounts.Domain,Demo.Tickets.Domain --snapshot-path dev/resource_snapshots --migration-path dev/repo/migrations --dont-drop-columns",
       credo: "credo --strict",
       migrate: "ash_postgres.migrate --migrations-path dev/repo/migrations",
       migrate_tenants: "ash_postgres.migrate --migrations-path dev/repo/tenant_migrations",


### PR DESCRIPTION
- points to proper migration-path
- --drop-columns was not a working option, assume this meant dont-drop-columns

### Contributor checklist

- [no] Bug fixes include regression tests
- [no] Features include unit/acceptance tests
