### PR TITLE
feat: implement close button for form

### DIFF
--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -83,7 +83,16 @@ defmodule AshAdmin.Components.Resource.Form do
 
   defp render_form(assigns) do
     ~H"""
-    <div class="shadow-lg overflow-hidden sm:rounded-md bg-white">
+    <div class="shadow-lg overflow-hidden sm:rounded-md bg-white relative">
+      <button
+        type="button"
+        phx-click="close_form"
+        phx-target={@myself}
+        class="text-red-500 absolute top-0 right-2 text-gray-600 hover:text-gray-800"
+        aria-label="Close"
+      >
+        &times;
+      </button>
       <div :if={@form.source.submitted_once?} class="ml-4 mt-4 text-red-500">
         <ul>
           <li :for={{field, message} <- all_errors(@form)}>
@@ -1632,6 +1641,14 @@ defmodule AshAdmin.Components.Resource.Form do
     {:noreply,
      socket
      |> assign(:form, form)}
+  end
+
+  def handle_event("close_form", _params, socket) do
+    domain = AshAdmin.Domain.name(socket.assigns.domain)
+    resource = AshAdmin.Resource.name(socket.assigns.resource)
+    params = "domain=#{domain}&resource=#{resource}"
+    to = "#{socket.assigns.prefix}?#{params}"
+    {:noreply, redirect(socket, to: to)}
   end
 
   def handle_event("append_value", %{"path" => path, "field" => field} = params, socket) do

--- a/lib/ash_admin/components/resource/relationship_field.ex
+++ b/lib/ash_admin/components/resource/relationship_field.ex
@@ -275,7 +275,11 @@ defmodule AshAdmin.Components.Resource.RelationshipField do
     |> Ash.Query.new()
     |> Ash.Query.load([pk_field, label_field])
     |> Ash.Query.limit(limit)
-    |> Ash.read!(actor: assigns[:actor], authorize?: assigns[:authorizing], tenant: assigns[:tenant])
+    |> Ash.read!(
+      actor: assigns[:actor],
+      authorize?: assigns[:authorizing],
+      tenant: assigns[:tenant]
+    )
     |> then(fn
       %Ash.Page.Offset{results: results} -> results
       results -> results


### PR DESCRIPTION
Playing around with ash admin on my project and I noticed I'm missing a close button for the forms.
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
