### PR TITLE
Update getting-started-with-ash-admin.md

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-admin.md
+++ b/documentation/tutorials/getting-started-with-ash-admin.md
@@ -9,7 +9,7 @@ https://www.youtube.com/watch?v=aFMLz3cpQ8c
 Add the `ash_admin` dependency to your `mix.exs` file:
 
 ```elixir
-{:ash_admin, "~> 0.11.4"}
+{:ash_admin, "~> 0.13.3"}
 ```
 
 ## Setup


### PR DESCRIPTION
Following the getting started guide, I was getting errors about an incompatible version of Phoenix LiveView with Ash Admin v0.11.

While searching on the Ash Discord I found the guidance was to use the latest version of Ash Admin.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
