### PR TITLE
fix: Handle cross-domain links

### DIFF
--- a/lib/ash_admin/components/resource/metadata_table.ex
+++ b/lib/ash_admin/components/resource/metadata_table.ex
@@ -98,7 +98,7 @@ defmodule AshAdmin.Components.Resource.MetadataTable do
               {relationship.type}
             </.td>
             <.td>
-              <.link navigate={"#{@prefix}?domain=#{AshAdmin.Domain.name(Ash.Resource.Info.domain(relationship.destination))}&resource=#{AshAdmin.Resource.name(relationship.destination)}"}>
+              <.link navigate={"#{@prefix}?domain=#{AshAdmin.Domain.name(relationship.domain || Ash.Resource.Info.domain(relationship.destination) || @domain)}&resource=#{AshAdmin.Resource.name(relationship.destination)}"}>
                 {AshAdmin.Resource.name(relationship.destination)}
               </.link>
             </.td>

--- a/lib/ash_admin/components/resource/metadata_table.ex
+++ b/lib/ash_admin/components/resource/metadata_table.ex
@@ -98,7 +98,7 @@ defmodule AshAdmin.Components.Resource.MetadataTable do
               {relationship.type}
             </.td>
             <.td>
-              <.link navigate={"#{@prefix}?domain=#{AshAdmin.Domain.name(@domain)}&resource=#{AshAdmin.Resource.name(relationship.destination)}"}>
+              <.link navigate={"#{@prefix}?domain=#{AshAdmin.Domain.name(Ash.Resource.Info.domain(relationship.destination))}&resource=#{AshAdmin.Resource.name(relationship.destination)}"}>
                 {AshAdmin.Resource.name(relationship.destination)}
               </.link>
             </.td>

--- a/lib/ash_admin/components/resource/show.ex
+++ b/lib/ash_admin/components/resource/show.ex
@@ -244,7 +244,7 @@ defmodule AshAdmin.Components.Resource.Show do
           <div class="px-4 py-3 text-right sm:px-6">
             <.link
               :if={AshAdmin.Resource.show_action(@destination)}
-              navigate={"#{@prefix}?domain=#{AshAdmin.Domain.name(@destination_domain || @domain)}&resource=#{AshAdmin.Resource.name(@destination)}&table=#{@context[:data_layer][:table]}&primary_key=#{encode_primary_key(@record)}&action_type=read"}
+              navigate={"#{@prefix}?domain=#{AshAdmin.Domain.name(@destination_domain || Ash.Resource.Info.domain(@destination))}&resource=#{AshAdmin.Resource.name(@destination)}&table=#{@context[:data_layer][:table]}&primary_key=#{encode_primary_key(@record)}&action_type=read"}
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             >
               Show
@@ -278,7 +278,7 @@ defmodule AshAdmin.Components.Resource.Show do
       <Table.table
         data={@data}
         resource={@destination}
-        domain={@domain}
+        domain={Ash.Resource.Info.domain(@destination)}
         table={@context[:data_layer][:table]}
         prefix={@prefix}
         skip={[@destination_attribute]}

--- a/lib/ash_admin/components/resource/show.ex
+++ b/lib/ash_admin/components/resource/show.ex
@@ -244,7 +244,7 @@ defmodule AshAdmin.Components.Resource.Show do
           <div class="px-4 py-3 text-right sm:px-6">
             <.link
               :if={AshAdmin.Resource.show_action(@destination)}
-              navigate={"#{@prefix}?domain=#{AshAdmin.Domain.name(@destination_domain || Ash.Resource.Info.domain(@destination))}&resource=#{AshAdmin.Resource.name(@destination)}&table=#{@context[:data_layer][:table]}&primary_key=#{encode_primary_key(@record)}&action_type=read"}
+              navigate={"#{@prefix}?domain=#{AshAdmin.Domain.name(@destination_domain || Ash.Resource.Info.domain(@destination) || @domain)}&resource=#{AshAdmin.Resource.name(@destination)}&table=#{@context[:data_layer][:table]}&primary_key=#{encode_primary_key(@record)}&action_type=read"}
               class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             >
               Show
@@ -260,7 +260,8 @@ defmodule AshAdmin.Components.Resource.Show do
          name: name,
          destination: destination,
          context: context,
-         destination_attribute: destination_attribute
+         destination_attribute: destination_attribute,
+         domain: destination_domain
        }) do
     data = Map.get(record, name)
 
@@ -268,6 +269,7 @@ defmodule AshAdmin.Components.Resource.Show do
       assign(assigns,
         data: data,
         destination: destination,
+        destination_domain: destination_domain,
         context: context,
         destination_attribute: destination_attribute,
         relationship_name: name
@@ -278,7 +280,7 @@ defmodule AshAdmin.Components.Resource.Show do
       <Table.table
         data={@data}
         resource={@destination}
-        domain={Ash.Resource.Info.domain(@destination)}
+        domain={@destination_domain || Ash.Resource.Info.domain(@destination) || @domain}
         table={@context[:data_layer][:table]}
         prefix={@prefix}
         skip={[@destination_attribute]}


### PR DESCRIPTION
Bug fixes for better managing cross-domain relationships. The bugs where that we didn't use the correct `domain` in the links when navigating to another resource.

This PR uses `Ash.Resource.Info.domain(relationship.destination)` to solve the issue.

I setup a test-project and clicked around to ensure that it didn't break anything 🙆‍♂️ 

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
