### PR TITLE
feature: add upload options for `Ash.Type.File` arguments

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 spark_locals_without_parens = [
+  accepted_extensions: 1,
   actor?: 1,
   create_actions: 1,
   default_resource_page: 1,
@@ -8,6 +9,7 @@ spark_locals_without_parens = [
   format_fields: 1,
   generic_actions: 1,
   label_field: 1,
+  max_file_size: 1,
   name: 1,
   polymorphic_actions: 1,
   polymorphic_tables: 1,

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,10 +1,3 @@
-# Contributing Guidelines
-
-Contributing guidelines can be found in the core project, [ash](https://github.com/ash-project/ash/blob/master/.github/CONTRIBUTING.md)
-
-
-
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,151 @@
-# Contributing Guidelines
+# Contributing to Ash
 
-Contributing guidelines can be found in the core project, [ash](https://github.com/ash-project/ash/blob/main/.github/CONTRIBUTING.md)
+## Welcome!
+
+We are delighted to have anyone contribute to Ash, regardless of their skill level or background. We welcome contributions both large and small, from typos and documentation improvements, to bug fixes and features. There is a place for everyone's contribution here. Check the issue tracker or join the ElixirForum/discord server to see how you can help! Make sure to read the rules below as well.
+
+## Contributing to Documentation
+
+Documentation contributions are one of the most valuable kinds of contributions you can make! Good documentation helps everyone in the community understand and use Ash more effectively.
+
+The best way to contribute to documentation is often through GitHub's web interface, which allows you to make changes without having to clone the code locally:
+
+**For Guides:**
+- While viewing any guide on the documentation website, look for the `</>` button in the top right of the page
+- Clicking this button will take you directly to GitHub's editing interface for that file
+
+![Guide Edit Button](documentation/assets/images/guides-link.png)
+
+**For Module Documentation:**
+- When viewing module documentation, the `</>` button will also be in the top right of the page
+
+**For Function Documentation:**
+- When viewing individual functions, you'll find the `</>` button next to the function header
+
+![Function Edit Button](documentation/assets/images/functions-link.png)
+
+Once you click the `</>` button, GitHub will:
+1. Fork the repository for you (if you haven't already)
+2. Open the file in GitHub's web editor
+3. Allow you to make your changes directly in the browser
+4. Help you create a pull request with your improvements
+
+This workflow makes it incredibly easy to fix typos, clarify explanations, add examples, or improve any part of the documentation you encounter while using Ash.
+
+## Rules
+
+* We have a zero tolerance policy for failure to abide by our code of conduct. It is very standard, but please make sure
+  you have read it.
+* Issues may be opened to propose new ideas, to ask questions, or to file bugs.
+* Before working on a feature, please talk to the core team/the rest of the community via a proposal. We are
+  building something that needs to be cohesive and well thought out across all use cases. Our top priority is
+  supporting real life use cases like yours, but we have to make sure that we do that in a sustainable way. The
+  best compromise there is to make sure that discussions are centered around the *use case* for a feature, rather
+  than the proposed feature itself.
+* Before starting work, please comment on the issue and/or ask in the discord if anyone is handling an issue. Be aware that if you've commented on an issue that you'd like to tackle it, but no one can reach you and/or demand/need arises sooner, it may still need to be done before you have a chance to finish. However, we will make all efforts to allow you to finish anything you claim.
+
+## Local Development & Testing
+
+### Setting Up Your Development Environment
+
+1. **Fork and clone the repository:**
+   ```bash
+   git clone https://github.com/your-username/ash.git
+   cd ash
+   ```
+
+2. **Install dependencies:**
+   ```bash
+   mix deps.get
+   ```
+
+3. **Compile the project:**
+   ```bash
+   mix compile
+   ```
+
+### Running Tests and Checks
+
+Before submitting any pull request, please run the full test suite and quality checks locally:
+
+```bash
+mix check
+```
+
+This command runs a comprehensive suite of checks including:
+- Compilation
+- Tests
+- Code formatting (via `spark.formatter`)
+- Credo (static code analysis)
+- Dialyzer (type checking)
+- Documentation generation and validation
+- Sobelow (security analysis)
+- And other quality checks
+
+You can also run individual checks:
+- `mix test` - Run the test suite
+- `mix format` - Format code
+- `mix credo` - Run static analysis
+- `mix dialyzer` - Run type checking
+- `mix docs` - Generate documentation
+
+### Testing Ash with Your Application
+
+If you want to test your Ash changes with your own application, you can use Ash as a local dependency. In your application's `mix.exs`, replace the hex dependency with a path dependency:
+
+```elixir
+defp deps do
+  [
+    # Replace this:
+    # {:ash, "~> 3.0"}
+
+    # With this (adjust path as needed):
+    {:ash, path: "../ash"},
+
+    # Your other dependencies...
+  ]
+end
+```
+
+Then run:
+```bash
+mix deps.get
+mix compile
+```
+
+This allows you to:
+- Test your changes against real-world usage
+- Verify that your changes don't break existing functionality
+- Develop features iteratively with immediate feedback
+
+Testing in your own application is not sufficient, you must also include automated tests.
+
+### Development Workflow
+
+1. **Create a feature branch:**
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Make your changes** and write tests
+
+3. **Run the full check suite:**
+   ```bash
+   mix check
+   ```
+
+4. **Commit your changes:**
+   ```bash
+   git add .
+   git commit -m "Add feature description"
+   ```
+
+5. **Push and create a pull request**
+
+### Common Development Tasks
+
+- **Generate documentation:** `mix docs`
+- **Run tests in watch mode:** `mix test.watch`
+- **Check formatting:** `mix format --check-formatted`
+- **Run specific test file:** `mix test test/path/to/test_file.exs`
+- **Run tests with coverage:** `mix test --cover`

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,19 +4,15 @@ about: Create a report to help us improve
 title: ''
 labels: bug, needs review
 assignees: ''
-
 ---
 
 **Describe the bug**
-
-A clear and concise description of what the bug is. If you are not sure if the bug is related to `ash` or an extension, log it with [ash](https://github.com/ash-project/ash/issues/new) and we will move it.
+A clear and concise description of what the bug is.
 
 **To Reproduce**
-
 A minimal set of resource definitions and calls that can reproduce the bug.
 
 **Expected behavior**
-
 A clear and concise description of what you expected to happen.
 
 **Runtime**
@@ -24,8 +20,7 @@ A clear and concise description of what you expected to happen.
  - Erlang version
  - OS
  - Ash version
- - any related extension versions
+ - any related package versions
 
 **Additional context**
-
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,9 +1,9 @@
 ---
 name: Proposal
 about: Suggest an idea for this project
-title: ""
+title: ''
 labels: enhancement, needs review
-assignees: ""
+assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
@@ -14,22 +14,6 @@ A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
-
-**Express the feature either with a change to resource syntax, or with a change to the resource interface**
-
-For example
-
-```elixir
-  attributes do
-    attribute :foo, :integer, bar: 10 # <- Adding `bar` here would cause <x>
-  end
-```
-
-Or
-
-```elixir
-  Ash.read(:resource, bar: 10) # <- Adding `bar` here would cause <x>
-```
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,10 @@
-### Contributor checklist
+# Contributor checklist
+
+Leave anything that you believe does not apply unchecked.
 
 - [ ] Bug fixes include regression tests
+- [ ] Chores
+- [ ] Documentation changes
 - [ ] Features include unit/acceptance tests
+- [ ] Refactoring
+- [ ] Update dependencies

--- a/dev/resources/tickets/resources/customer.ex
+++ b/dev/resources/tickets/resources/customer.ex
@@ -9,10 +9,17 @@ defmodule Demo.Tickets.Customer do
       AshAdmin.Resource
     ]
 
-    admin do
-      relationship_display_fields [:id, :first_name]
-      label_field :full_name
+  admin do
+    relationship_display_fields [:id, :first_name]
+    label_field :full_name
+
+    form do
+      field :photo do
+        max_file_size 8_000_000
+        accepted_extensions ["image/*"]
+      end
     end
+  end
 
   resource do
     base_filter representative: false

--- a/dev/resources/tickets/resources/ticket/ticket.ex
+++ b/dev/resources/tickets/resources/ticket/ticket.ex
@@ -22,6 +22,11 @@ defmodule Demo.Tickets.Ticket do
 
     form do
       field :description, type: :markdown
+
+      field :photo do
+        max_file_size 12_000_000
+        accepted_extensions ["image/*"]
+      end
     end
   end
 

--- a/documentation/dsls/DSL-AshAdmin.Resource.md
+++ b/documentation/dsls/DSL-AshAdmin.Resource.md
@@ -72,7 +72,9 @@ Declare non-default behavior for a specific attribute.
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`type`](#admin-form-field-type){: #admin-form-field-type .spark-required} | `:default \| :long_text \| :short_text \| :markdown` |  | The type of the value in the form. Use `default` if you are just specifying field order |
+| [`type`](#admin-form-field-type){: #admin-form-field-type } | `:default \| :long_text \| :short_text \| :markdown` |  | The type of the value in the form. Use `default` if you are just specifying field order |
+| [`max_file_size`](#admin-form-field-max_file_size){: #admin-form-field-max_file_size } | `integer` |  | The maximum file size in bytes to allow to be uploaded. Only applicable to action arguments of `Ash.Type.File`. |
+| [`accepted_extensions`](#admin-form-field-accepted_extensions){: #admin-form-field-accepted_extensions } | `any \| list(String.t)` |  | A list of unique file extensions (such as ".jpeg") or mime type (such as "image/jpeg" or "image/*"). Only applicable to action arguments of `Ash.Type.File`. |
 
 
 

--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -2379,13 +2379,22 @@ defmodule AshAdmin.Components.Resource.Form do
     |> Enum.flat_map(fn form ->
       form
       |> uploadable_arguments()
-      |> Enum.map(fn argument -> upload_key(form, argument) end)
+      |> Enum.map(fn argument ->
+        %{
+          upload_key: upload_key(form, argument),
+          field: AshAdmin.Resource.field(form.resource, argument.name)
+        }
+      end)
     end)
-    |> Enum.reduce(socket, fn upload_key, socket ->
+    |> Enum.reduce(socket, fn %{upload_key: upload_key, field: field}, socket ->
       if upload_allowed?(socket, upload_key) do
         socket
       else
-        allow_upload(socket, upload_key, accept: :any)
+        allow_upload(socket, upload_key,
+          accept: field[:accepted_extensions] || :any,
+          # 8 megabyte (SI) default
+          max_file_size: field[:max_file_size] || 8_000_000
+        )
       end
     end)
   end

--- a/lib/ash_admin/resource/field.ex
+++ b/lib/ash_admin/resource/field.ex
@@ -2,7 +2,7 @@ defmodule AshAdmin.Resource.Field do
   @moduledoc """
   The representation of a configured field in the admin UI.
   """
-  defstruct [:name, :type, :default]
+  defstruct [:name, :type, :default, :max_file_size, :accepted_extensions]
 
   @schema [
     name: [
@@ -12,9 +12,21 @@ defmodule AshAdmin.Resource.Field do
     ],
     type: [
       type: {:in, [:default, :long_text, :short_text, :markdown]},
-      required: true,
+      required: false,
       doc:
         "The type of the value in the form. Use `default` if you are just specifying field order"
+    ],
+    max_file_size: [
+      type: :integer,
+      required: false,
+      doc:
+        "The maximum file size in bytes to allow to be uploaded. Only applicable to action arguments of `Ash.Type.File`."
+    ],
+    accepted_extensions: [
+      type: {:or, [:any, {:list, :string}]},
+      required: false,
+      doc:
+        "A list of unique file extensions (such as \".jpeg\") or mime type (such as \"image/jpeg\" or \"image/*\"). Only applicable to action arguments of `Ash.Type.File`."
     ]
   ]
 

--- a/lib/ash_admin/resource/resource.ex
+++ b/lib/ash_admin/resource/resource.ex
@@ -120,6 +120,9 @@ defmodule AshAdmin.Resource do
     transformers: [
       AshAdmin.Resource.Transformers.ValidateTableColumns,
       AshAdmin.Resource.Transformers.AddPositionSortCalculation
+    ],
+    verifiers: [
+      AshAdmin.Resource.Verifiers.VerifyFileArgumentsExist
     ]
 
   @moduledoc """

--- a/lib/ash_admin/resource/verifiers/verify_file_arguments_exist.ex
+++ b/lib/ash_admin/resource/verifiers/verify_file_arguments_exist.ex
@@ -1,0 +1,50 @@
+defmodule AshAdmin.Resource.Verifiers.VerifyFileArgumentsExist do
+  @moduledoc """
+  Ensures that an argument with file options exists in an action of the
+  resource.
+  """
+
+  use Spark.Dsl.Verifier
+
+  alias Spark.Dsl.Verifier
+
+  def verify(dsl_state) do
+    dsl_state
+    |> AshAdmin.Resource.fields()
+    |> Enum.filter(&file_options_set?/1)
+    |> Enum.reduce_while(:ok, fn field, _acc ->
+      if argument_exists?(dsl_state, field.name) do
+        {:cont, :ok}
+      else
+        {:halt,
+         {:error,
+          Spark.Error.DslError.exception(
+            message: """
+            `#{field.name}` has `max_file_size` or `accepted_extensions` set but
+            `#{module_name(dsl_state)}` has no action with an argument named `#{field.name}` with type `Ash.File.Type`.",
+            """,
+            path: [:admin, :form, :field, field.name],
+            module: Verifier.get_persisted(dsl_state, :module)
+          )}}
+      end
+    end)
+  end
+
+  defp module_name(dsl_state) do
+    String.trim_leading(to_string(Verifier.get_persisted(dsl_state, :module)), "Elixir.")
+  end
+
+  defp argument_exists?(dsl_state, name) do
+    dsl_state
+    |> Ash.Resource.Info.actions()
+    |> Enum.flat_map(fn action -> action.arguments end)
+    |> Enum.any?(fn argument ->
+      argument.name == name
+    end)
+  end
+
+  defp file_options_set?(field) do
+    not is_nil(field.max_file_size) or
+      not is_nil(field.accepted_extensions)
+  end
+end


### PR DESCRIPTION
There are a couple options for file uploads that are currently hardcoded that would be useful to expose. For example, it would be nice to be able to upload files larger than 8 megabytes. 

I've adjusted the AshAdmin DSL to allow for specifying `max_file_size` in bytes and `accepted_extensions` for what type of files to allow uploading. These options are passed directly to the LiveView [allow_upload](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#allow_upload/3) call and mirror it's documentation.

I've also added a verify step to the AshAdmin DSL to ensure that an argument with these new file options exist in an action of the resource.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
