### PR TITLE
feat: make generic actions async

### DIFF
--- a/priv/static/assets/app.css
+++ b/priv/static/assets/app.css
@@ -1402,6 +1402,10 @@ select {
   animation: spin 1s linear infinite;
 }
 
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+
 .cursor-pointer {
   cursor: pointer;
 }
@@ -1630,6 +1634,11 @@ select {
   background-color: rgb(209 213 219 / var(--tw-bg-opacity));
 }
 
+.bg-gray-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(156 163 175 / var(--tw-bg-opacity));
+}
+
 .bg-gray-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(75 85 99 / var(--tw-bg-opacity));
@@ -1809,6 +1818,11 @@ select {
   text-align: right;
 }
 
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
@@ -1904,6 +1918,11 @@ select {
 .text-gray-900 {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
+}
+
+.text-green-500 {
+  --tw-text-opacity: 1;
+  color: rgb(34 197 94 / var(--tw-text-opacity));
 }
 
 .text-red-500 {

--- a/priv/static/assets/app.js
+++ b/priv/static/assets/app.js
@@ -2348,7 +2348,7 @@
       return el.getAttribute && el.getAttribute(phxTriggerExternal) !== null && document.body.contains(el);
     },
     cleanChildNodes(container, phxUpdate) {
-      if (DOM.isPhxUpdate(container, phxUpdate, ["append", "prepend"])) {
+      if (DOM.isPhxUpdate(container, phxUpdate, ["append", "prepend", PHX_STREAM])) {
         let toRemove = [];
         container.childNodes.forEach((childNode) => {
           if (!childNode.id) {
@@ -2668,7 +2668,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       return classes.find((name) => instance instanceof name);
     },
     isFocusable(el, interactiveOnly) {
-      return el instanceof HTMLAnchorElement && el.rel !== "ignore" || el instanceof HTMLAreaElement && el.href !== void 0 || !el.disabled && this.anyOf(el, [HTMLInputElement, HTMLSelectElement, HTMLTextAreaElement, HTMLButtonElement]) || el instanceof HTMLIFrameElement || (el.tabIndex >= 0 || !interactiveOnly && el.getAttribute("tabindex") !== null && el.getAttribute("aria-hidden") !== "true");
+      return el instanceof HTMLAnchorElement && el.rel !== "ignore" || el instanceof HTMLAreaElement && el.href !== void 0 || !el.disabled && this.anyOf(el, [HTMLInputElement, HTMLSelectElement, HTMLTextAreaElement, HTMLButtonElement]) || el instanceof HTMLIFrameElement || (el.tabIndex >= 0 && el.getAttribute("aria-hidden") !== "true" || !interactiveOnly && el.getAttribute("tabindex") !== null && el.getAttribute("aria-hidden") !== "true");
     },
     attemptFocus(el, interactiveOnly) {
       if (this.isFocusable(el, interactiveOnly)) {
@@ -6327,7 +6327,8 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
         const clonedForm = form.cloneNode(false);
         dom_default.copyPrivates(clonedForm, form);
         Array.from(form.elements).forEach((el) => {
-          const clonedEl = el.cloneNode(false);
+          const clonedEl = el.cloneNode(true);
+          morphdom_esm_default(clonedEl, el);
           dom_default.copyPrivates(clonedEl, el);
           clonedForm.appendChild(clonedEl);
         });
@@ -6441,7 +6442,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     }
     // public
     version() {
-      return "1.0.14";
+      return "1.0.17";
     }
     isProfileEnabled() {
       return this.sessionStorage.getItem(PHX_LV_PROFILE) === "true";
@@ -6712,7 +6713,13 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       return view;
     }
     owner(childEl, callback) {
-      let view = maybe(childEl.closest(PHX_VIEW_SELECTOR), (el) => this.getViewByEl(el)) || this.main;
+      let view;
+      const closestViewEl = childEl.closest(PHX_VIEW_SELECTOR);
+      if (closestViewEl) {
+        view = this.getViewByEl(closestViewEl);
+      } else {
+        view = this.main;
+      }
       return view && callback ? callback(view) : view;
     }
     withinOwners(childEl, callback) {


### PR DESCRIPTION
Makes generic actions async:
* fixes live view timeouts that prevent results from being displayed
* disable run button while action is running
* change text to 'Running...' while running for visual feedback
* if task crashes, show error
* some minor styling tweaks to result div

Notes:
* app.css and app.js were auto-generated, committed as-is

Context: https://discord.com/channels/711271361523351632/1380274836638535732

Made a generic action for backfilling some data, but it'd timeout + reload the live view, so it was hard to tell what happened.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
