### PR TITLE
Add `ash_admin: 2` in locals_without_parens

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -29,7 +29,8 @@ spark_locals_without_parens = [
 ]
 
 macro_locals_without_parens = [
-  ash_admin: 1
+  ash_admin: 1,
+  ash_admin: 2
 ]
 
 [


### PR DESCRIPTION
Currently, when you put `ash_admin "/route"` in your router with an `on_mount` option (or other options), the formatter puts parentheses around it because the options are a second argument. This should fix that.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
