### PR TITLE
fix: use `admin.show_action` when viewing a single record

### DIFF
--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -268,16 +268,15 @@ defmodule AshAdmin.PageLive do
                 socket.assigns.actor
               end
 
-            primary_read_action =
-              Ash.Resource.Info.primary_action(socket.assigns.resource, :read) ||
-                AshAdmin.Helpers.primary_action(socket.assigns.resource, :read)
+            show_action =
+              AshAdmin.Resource.show_action(socket.assigns.resource)
 
             record =
               socket.assigns.resource
               |> Ash.Query.filter(^primary_key)
               |> Ash.Query.set_tenant(socket.assigns[:tenant])
               |> Ash.Query.for_read(
-                primary_read_action.name,
+                show_action,
                 %{},
                 actor: actor,
                 authorize?: socket.assigns.authorizing


### PR DESCRIPTION
In the process of working with a resource with soft delete functionality, I've noticed the [documented](https://github.com/ash-project/ash_admin/blob/main/documentation/dsls/DSL-AshAdmin.Resource.md#admin-show_action) DSL `admin.show_action` option wasn't actually being used when showing a single record, so here's a quick fix.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
