### PR TITLE
chore: add ash_admin? flag to context

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-admin.md
+++ b/documentation/tutorials/getting-started-with-ash-admin.md
@@ -236,6 +236,11 @@ ash_admin "/admin", csp_nonce_assign_key: :csp_nonce_value
 
 This will allow AshAdmin-generated inline CSS and JS blocks to execute normally.
 
+## Action Context
+
+AshAdmin adds `ash_admin?: true` to the context of all AshPhoenix forms it uses (read, update, and
+generic actions). This allows upstream logic to know if an action is being called by AshAdmin.
+
 ## Troubleshooting
 
 #### UI issues

--- a/lib/ash_admin/components/resource/data_table.ex
+++ b/lib/ash_admin/components/resource/data_table.ex
@@ -269,6 +269,7 @@ defmodule AshAdmin.Components.Resource.DataTable do
         else
           %{}
         end
+        |> Map.put(:ash_admin?, true)
 
       query =
         socket.assigns[:resource]

--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -2743,40 +2743,29 @@ defmodule AshAdmin.Components.Resource.Form do
         include_non_map_types?: true
       )
 
+    form_opts = [
+      actor: socket.assigns[:actor],
+      authorize?: socket.assigns[:authorizing],
+      context: %{ash_admin?: true},
+      domain: socket.assigns.domain,
+      forms: auto_forms,
+      tenant: socket.assigns[:tenant],
+      transform_errors: transform_errors
+    ]
+
     form =
       case socket.assigns.action.type do
         :create ->
           socket.assigns.resource
-          |> AshPhoenix.Form.for_create(socket.assigns.action.name,
-            domain: socket.assigns.domain,
-            actor: socket.assigns[:actor],
-            authorize?: socket.assigns[:authorizing],
-            forms: auto_forms,
-            transform_errors: transform_errors,
-            tenant: socket.assigns[:tenant]
-          )
+          |> AshPhoenix.Form.for_create(socket.assigns.action.name, form_opts)
 
         :update ->
           socket.assigns.record
-          |> AshPhoenix.Form.for_update(socket.assigns.action.name,
-            domain: socket.assigns.domain,
-            forms: auto_forms,
-            actor: socket.assigns[:actor],
-            authorize?: socket.assigns[:authorizing],
-            transform_errors: transform_errors,
-            tenant: socket.assigns[:tenant]
-          )
+          |> AshPhoenix.Form.for_update(socket.assigns.action.name, form_opts)
 
         :destroy ->
           socket.assigns.record
-          |> AshPhoenix.Form.for_destroy(socket.assigns.action.name,
-            domain: socket.assigns.domain,
-            forms: auto_forms,
-            actor: socket.assigns[:actor],
-            authorize?: socket.assigns[:authorizing],
-            transform_errors: transform_errors,
-            tenant: socket.assigns[:tenant]
-          )
+          |> AshPhoenix.Form.for_destroy(socket.assigns.action.name, form_opts)
       end
 
     assign(socket, :form, form |> to_form())

--- a/lib/ash_admin/components/resource/generic_action.ex
+++ b/lib/ash_admin/components/resource/generic_action.ex
@@ -253,6 +253,7 @@ defmodule AshAdmin.Components.Resource.GenericAction do
         else
           %{}
         end
+        |> Map.put(:ash_admin?, true)
 
       form =
         AshPhoenix.Form.for_action(socket.assigns.resource, socket.assigns.action.name,


### PR DESCRIPTION
This commit adds `ash_admin?: true` to the context of all AshPhoenix forms so that upstream logic can tell if an action is being called from AshAdmin or not.

While doing so, I noticed that all three form calls (`for_create/3`, `for_update/3`, and `for_destroy/3`) were using the exact same options, so I refactored them into a shared variable. I hope this is OK, but I can roll these changes back and only add the new flag if you prefer.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
  - AI was not used.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
