### PR TITLE
Support tenant option labels

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-admin.md
+++ b/documentation/tutorials/getting-started-with-ash-admin.md
@@ -94,7 +94,7 @@ By default, the tenant field in the admin navbar is a free-text input. You can c
 
 ### Dropdown
 
-If the function referenced by the MFA takes no additional arguments (i.e. the arity equals the length of the args list), AshAdmin renders a dropdown select with the returned list of tenant strings:
+If the function referenced by the MFA takes no additional arguments (i.e. the arity equals the length of the args list), AshAdmin renders a dropdown select. The function can return a list of tenant values:
 
 ```elixir
 config :ash_admin, :list_tenants, {MyApp.Tenants, :list_tenants, []}
@@ -103,15 +103,27 @@ config :ash_admin, :list_tenants, {MyApp.Tenants, :list_tenants, []}
 ```elixir
 defmodule MyApp.Tenants do
   def list_tenants do
-    # Return a list of tenant identifier strings
     ["tenant_a", "tenant_b", "tenant_c"]
+  end
+end
+```
+
+To show friendly labels while submitting tenant ids, return atom-keyed label/value maps:
+
+```elixir
+defmodule MyApp.Tenants do
+  def list_tenants do
+    [
+      %{label: "Dev Lab", value: "1"},
+      %{label: "Production Lab", value: "2"}
+    ]
   end
 end
 ```
 
 ### Typeahead
 
-If the function takes one additional argument beyond the args list, AshAdmin renders a typeahead input. The extra argument is the search text the user has typed:
+If the function takes one additional argument beyond the args list, AshAdmin renders a typeahead input. The extra argument is the search text the user has typed. The function can return tenant values or atom-keyed label/value maps:
 
 ```elixir
 config :ash_admin, :list_tenants, {MyApp.Tenants, :search_tenants, []}
@@ -121,11 +133,10 @@ config :ash_admin, :list_tenants, {MyApp.Tenants, :search_tenants, []}
 defmodule MyApp.Tenants do
   def search_tenants(""), do: []
   def search_tenants(search) do
-    # Return a filtered list of tenant identifier strings
     MyApp.Repo.all(
       from t in "tenants",
         where: ilike(t.name, ^"%#{search}%"),
-        select: t.name
+        select: %{label: t.name, value: t.id}
     )
   end
 end

--- a/lib/ash_admin.ex
+++ b/lib/ash_admin.ex
@@ -24,12 +24,32 @@ defmodule AshAdmin do
   @doc false
   def list_tenants do
     {m, f, a} = Application.get_env(:ash_admin, :list_tenants)
-    apply(m, f, a)
+
+    m
+    |> apply(f, a)
+    |> normalize_tenant_options()
   end
 
   @doc false
   def search_tenants(search) do
     {m, f, a} = Application.get_env(:ash_admin, :list_tenants)
-    apply(m, f, a ++ [search])
+
+    m
+    |> apply(f, a ++ [search])
+    |> normalize_tenant_options()
+  end
+
+  @doc false
+  def normalize_tenant_options(options) do
+    Enum.map(options, &normalize_tenant_option/1)
+  end
+
+  defp normalize_tenant_option(%{label: label, value: value}) do
+    %{label: to_string(label), value: to_string(value)}
+  end
+
+  defp normalize_tenant_option(value) do
+    value = to_string(value)
+    %{label: value, value: value}
   end
 end

--- a/lib/ash_admin/components/sidebar.ex
+++ b/lib/ash_admin/components/sidebar.ex
@@ -18,6 +18,7 @@ defmodule AshAdmin.Components.Sidebar do
   attr :actor_tenant, :any, default: nil
   attr :authorizing, :boolean, default: true
   attr :tenant, :any, default: nil
+  attr :tenant_label, :any, default: nil
   attr :tenant_mode, :atom, default: nil
   attr :tenant_options, :list, default: []
   attr :tenant_suggestions, :list, default: []
@@ -197,7 +198,9 @@ defmodule AshAdmin.Components.Sidebar do
           class="w-full text-sm rounded-md bg-slate-800 border-slate-700 text-slate-300 focus:border-slate-500 focus:ring-slate-500"
         >
           <option value="">No tenant</option>
-          <option :for={t <- @tenant_options} value={t} selected={t == @tenant}>{t}</option>
+          <option :for={t <- @tenant_options} value={t.value} selected={t.value == @tenant}>
+            {t.label}
+          </option>
         </select>
       </.form>
     </div>
@@ -224,10 +227,11 @@ defmodule AshAdmin.Components.Sidebar do
               <button
                 type="button"
                 phx-click="set_tenant"
-                phx-value-tenant={s}
+                phx-value-tenant={s.value}
+                phx-value-tenant_label={s.label}
                 class="w-full text-left px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-700 cursor-pointer"
               >
-                {s}
+                {s.label}
               </button>
             </li>
           </ul>
@@ -252,7 +256,7 @@ defmodule AshAdmin.Components.Sidebar do
       </div>
       <div :if={!@editing_tenant} class="flex items-center gap-2 text-sm">
         <a href="#" phx-click="start_editing_tenant" class="text-slate-400 hover:text-white">
-          {if @tenant, do: @tenant, else: "No tenant — Set"}
+          {tenant_display(assigns)}
         </a>
         <button
           :if={@tenant}
@@ -291,7 +295,7 @@ defmodule AshAdmin.Components.Sidebar do
       </div>
       <div :if={!@editing_tenant} class="flex items-center gap-2 text-sm">
         <a href="#" phx-click="start_editing_tenant" class="text-slate-400 hover:text-white">
-          {if @tenant, do: @tenant, else: "No tenant — Set"}
+          {tenant_display(assigns)}
         </a>
         <button
           :if={@tenant}
@@ -371,6 +375,14 @@ defmodule AshAdmin.Components.Sidebar do
         if group_index > 0, do: nil, else: nil
     end
   end
+
+  defp tenant_display(%{tenant: tenant}) when tenant in [nil, ""], do: "No tenant — Set"
+
+  defp tenant_display(%{tenant_label: tenant_label}) when tenant_label not in [nil, ""] do
+    tenant_label
+  end
+
+  defp tenant_display(%{tenant: tenant}), do: tenant
 
   defp show_tenant?(_domains, tenant_mode) when tenant_mode in [:dropdown, :typeahead], do: true
 

--- a/lib/ash_admin/pages/page_live.ex
+++ b/lib/ash_admin/pages/page_live.ex
@@ -62,6 +62,7 @@ defmodule AshAdmin.PageLive do
      |> assign(:record, nil)
      |> assign(:domains, domains)
      |> assign(:tenant, session["tenant"])
+     |> assign(:tenant_label, nil)
      |> assign(:editing_tenant, false)
      |> assign(:tenant_mode, tenant_mode)
      |> assign(:tenant_options, tenant_options)
@@ -96,6 +97,7 @@ defmodule AshAdmin.PageLive do
         actor_tenant={@actor_tenant}
         authorizing={@authorizing}
         tenant={@tenant}
+        tenant_label={@tenant_label}
         tenant_mode={@tenant_mode}
         tenant_options={@tenant_options}
         tenant_suggestions={@tenant_suggestions}
@@ -483,11 +485,13 @@ defmodule AshAdmin.PageLive do
   def handle_event("set_tenant", data, socket) do
     tenant = data["tenant"]
     tenant = if tenant in [nil, ""], do: nil, else: tenant
+    tenant_label = if tenant, do: data["tenant_label"], else: nil
 
     socket =
       socket
       |> assign(:editing_tenant, false)
       |> assign(:tenant, tenant)
+      |> assign(:tenant_label, tenant_label)
       |> assign(:tenant_suggestions, [])
 
     if tenant do
@@ -501,6 +505,7 @@ defmodule AshAdmin.PageLive do
     {:noreply,
      socket
      |> assign(:tenant, nil)
+     |> assign(:tenant_label, nil)
      |> push_event("clear_tenant", %{})}
   end
 

--- a/test/tenant_options_test.exs
+++ b/test/tenant_options_test.exs
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2020 ash_admin contributors <https://github.com/ash-project/ash_admin/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAdmin.Test.TenantOptionsTest do
+  use ExUnit.Case, async: false
+
+  defmodule Tenants do
+    def list_tenants do
+      ["tenant_a", %{label: "Dev Lab", value: 1}]
+    end
+
+    def search_tenants(search) do
+      [%{label: "#{search} Lab", value: search}]
+    end
+  end
+
+  setup do
+    previous = Application.get_env(:ash_admin, :list_tenants)
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:ash_admin, :list_tenants, previous)
+      else
+        Application.delete_env(:ash_admin, :list_tenants)
+      end
+    end)
+  end
+
+  test "normalizes values and atom-keyed label/value tenant options" do
+    assert AshAdmin.normalize_tenant_options([
+             "tenant_a",
+             %{label: "Dev Lab", value: 1}
+           ]) == [
+             %{label: "tenant_a", value: "tenant_a"},
+             %{label: "Dev Lab", value: "1"}
+           ]
+  end
+
+  test "list_tenants returns normalized label/value tenant options" do
+    Application.put_env(:ash_admin, :list_tenants, {Tenants, :list_tenants, []})
+
+    assert AshAdmin.list_tenants() == [
+             %{label: "tenant_a", value: "tenant_a"},
+             %{label: "Dev Lab", value: "1"}
+           ]
+  end
+
+  test "search_tenants returns normalized label/value tenant options" do
+    Application.put_env(:ash_admin, :list_tenants, {Tenants, :search_tenants, []})
+
+    assert AshAdmin.search_tenants("Dev") == [%{label: "Dev Lab", value: "Dev"}]
+  end
+end


### PR DESCRIPTION
Fixes #405.

- Accept atom-keyed `%{label: ..., value: ...}` tenant options from `list_tenants` and typeahead search
- Normalize existing value lists into label/value options for backwards compatibility
- Render labels while submitting tenant values

Tested with `mix test`.
