### PR TITLE
fix: pass actor, authorize?, and tenant in RelationshipField reads

### DIFF
--- a/lib/ash_admin/components/resource/relationship_field.ex
+++ b/lib/ash_admin/components/resource/relationship_field.ex
@@ -38,7 +38,7 @@ defmodule AshAdmin.Components.Resource.RelationshipField do
   def update(assigns, socket) do
     pk_field = Ash.Resource.Info.primary_key(assigns.resource) |> List.first()
     label_field = AshAdmin.Resource.label_field(assigns.resource)
-    current_label = get_current_label(assigns.resource, assigns.value, label_field)
+    current_label = get_current_label(assigns.resource, assigns.value, label_field, ash_opts(assigns))
 
     {:ok,
      assign(socket, assigns)
@@ -51,20 +51,24 @@ defmodule AshAdmin.Components.Resource.RelationshipField do
      )}
   end
 
-  defp get_current_label(_, nil, _) do
+  defp get_current_label(_, nil, _, _) do
     ""
   end
 
-  defp get_current_label(resource, value, label_field) do
-    case resource |> Ash.get(value) do
+  defp get_current_label(resource, value, label_field, opts) do
+    case resource |> Ash.get(value, opts) do
       {:ok, record} ->
         record
-        |> Ash.load!(label_field)
+        |> Ash.load!(label_field, opts)
         |> Map.get(label_field)
 
       _ ->
         ""
     end
+  end
+
+  defp ash_opts(assigns) do
+    [actor: assigns[:actor], authorize?: assigns[:authorizing], tenant: assigns[:tenant]]
   end
 
   @spec render(atom() | %{:resource => atom() | Ash.Query.t(), optional(any()) => any()}) ::
@@ -235,7 +239,8 @@ defmodule AshAdmin.Components.Resource.RelationshipField do
           get_current_label(
             socket.assigns.resource,
             original_value,
-            socket.assigns.label_field
+            socket.assigns.label_field,
+            ash_opts(socket.assigns)
           )
 
         {:noreply,
@@ -315,7 +320,7 @@ defmodule AshAdmin.Components.Resource.RelationshipField do
     )
     |> Ash.Query.sort(ash_admin_position_sort: {%{search_term: search_term}, :asc})
     |> Ash.Query.limit(assigns.max_items)
-    |> Ash.read!()
+    |> Ash.read!(ash_opts(assigns))
     |> Enum.map(&{Map.get(&1, assigns.label_field), &1.id})
   end
 end

--- a/test/components/resource/relationship_field_test.exs
+++ b/test/components/resource/relationship_field_test.exs
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2020 ash_admin contributors <https://github.com/ash-project/ash_admin/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAdmin.Test.RelationshipFieldTest do
+  use ExUnit.Case, async: true
+
+  alias AshAdmin.Components.Resource.RelationshipField
+
+  defmodule Domain do
+    @moduledoc false
+    use Ash.Domain, validate_config_inclusion?: false
+
+    authorization do
+      require_actor? true
+    end
+
+    resources do
+      allow_unregistered? true
+    end
+  end
+
+  defmodule Artist do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshAdmin.Resource]
+
+    ets do
+      private? true
+    end
+
+    admin do
+      label_field :name
+    end
+
+    actions do
+      defaults [:read]
+
+      create :create do
+        accept [:name]
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true
+    end
+  end
+
+  defp component_socket(artist) do
+    {:ok, socket} = RelationshipField.mount(%Phoenix.LiveView.Socket{})
+
+    assigns = %{
+      id: "form-artist_id",
+      resource: Artist,
+      value: artist.id,
+      actor: nil,
+      authorizing: false,
+      tenant: nil
+    }
+
+    {:ok, socket} = RelationshipField.update(assigns, socket)
+    socket
+  end
+
+  defp artist! do
+    Artist
+    |> Ash.Changeset.for_create(:create, %{name: "Prince"}, actor: nil, authorize?: false)
+    |> Ash.create!()
+  end
+
+  test "update/2 passes actor options to the label lookup on a require_actor? domain" do
+    socket = component_socket(artist!())
+
+    assert socket.assigns.current_label == "Prince"
+  end
+
+  test "suggest passes actor options to the search on a require_actor? domain" do
+    socket = component_socket(artist!())
+
+    {:noreply, socket} =
+      RelationshipField.handle_event("suggest", %{"value" => "Pri", "key" => "P"}, socket)
+
+    assert [{"Prince", _id}] = socket.assigns.suggestions
+  end
+end


### PR DESCRIPTION
Ran into a crash when using `label_field` along with `require_actor? true`, since the actor wasn't being passed along to these.

> The domain Foo.Bar requires that an actor is provided at all times and none was provided.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
