### PR TITLE
fix: handle nil values when rendering AshTypedStructures

### DIFF
--- a/lib/ash_admin/components/resource/show.ex
+++ b/lib/ash_admin/components/resource/show.ex
@@ -493,7 +493,10 @@ defmodule AshAdmin.Components.Resource.Show do
     struct_map =
       record
       |> Map.get(attribute.name)
-      |> Map.from_struct()
+      |> case do
+        nil -> nil
+        value -> Map.from_struct(value)
+      end
 
     render_attribute(
       assigns,


### PR DESCRIPTION
# Contributor checklist

Calling `Map.from_struct(value)` on nil crashes the page. And I did not consider that the Ash Typed Structure could be nil when I submitted my previous changes (https://github.com/ash-project/ash_admin/pull/420). 

This PR add a case statement that will prevent the app from crashing on nil values. The app already handle nil value by showing rendering null.

https://github.com/user-attachments/assets/17dcac73-8c14-4f15-9ba4-ecd978445d68



Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
