### PR TITLE
fix: parse TypedStruct as map in forms for update actions

### DIFF
--- a/dev/resources/accounts/resources/user.ex
+++ b/dev/resources/accounts/resources/user.ex
@@ -74,6 +74,7 @@ defmodule Demo.Accounts.User do
 
     update :update do
       primary? true
+      require_atomic? false
       argument :offices, {:array, :map}
       change manage_relationship(:offices, type: :append_and_remove)
     end

--- a/lib/ash_admin/components/resource/form.ex
+++ b/lib/ash_admin/components/resource/form.ex
@@ -1327,6 +1327,16 @@ defmodule AshAdmin.Components.Resource.Form do
     render_attribute_input(assigns, %{attribute | type: Ash.Type.Map}, form, value, name, id)
   end
 
+  def render_attribute_input(assigns, %{type: Ash.Type.Struct} = attribute, form, value, name, id, _) do
+    value =
+      case value(value, form, attribute) do
+        %_{} = struct -> Map.from_struct(struct)
+        other -> other
+      end
+
+    render_attribute_input(assigns, %{attribute | type: Ash.Type.Map}, form, value, name, id)
+  end
+
   def render_attribute_input(assigns, %{type: Ash.Type.Map} = attribute, form, value, name, id, _) do
     encoded = Jason.encode!(value(value, form, attribute))
 


### PR DESCRIPTION
# Contributor checklist

This PR converts `Ash.Type.Struct` to `Ash.Type.Map` so that the struct can get rendered in the form and be updated using the admin UI.

Note that I haven't added/updated any tests after this change because I wasn't sure where to do this exactly. Please let me know if and where you want me to add tests for this change. FWIW, I have tested the changes locally and have included videos of before and after this change. 

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Before the change

https://github.com/user-attachments/assets/809e65bf-b39a-43cd-ac16-67f10e4ef0d0

## After the change

https://github.com/user-attachments/assets/790ebd12-3242-4447-b4a8-82b1672e2a76

